### PR TITLE
Add authentication and user management support for TypeDB Cluster

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -57,6 +57,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
@@ -78,10 +79,14 @@ import static java.util.stream.Collectors.toList;
 
 public class TypeDBConsole {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TypeDBConsole.class);
     private static final String COPYRIGHT = "\n" +
             "Welcome to TypeDB Console. You are now in TypeDB Wonderland!\n" +
             "Copyright (C) 2021 Vaticle\n";
+    private static final Path COMMAND_HISTORY_FILE =
+            Paths.get(System.getProperty("user.home"), ".typedb-console-command-history").toAbsolutePath();
+    private static final Path TRANSACTION_HISTORY_FILE =
+            Paths.get(System.getProperty("user.home"), ".typedb-console-transaction-history").toAbsolutePath();
+    private static final Logger LOG = LoggerFactory.getLogger(TypeDBConsole.class);
 
     private final Printer printer;
     private ExecutorService executorService;
@@ -230,7 +235,7 @@ public class TypeDBConsole {
     private void runRepl(TypeDBClient client) {
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
-                .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".typedb-console-command-history").toAbsolutePath())
+                .variable(LineReader.HISTORY_FILE, COMMAND_HISTORY_FILE)
                 .build();
         while (true) {
             ReplCommand command;
@@ -280,7 +285,7 @@ public class TypeDBConsole {
     private boolean runTransactionRepl(TypeDBClient client, String database, TypeDBSession.Type sessionType, TypeDBTransaction.Type transactionType, TypeDBOptions options) {
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
-                .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".typedb-console-transaction-history").toAbsolutePath())
+                .variable(LineReader.HISTORY_FILE, TRANSACTION_HISTORY_FILE)
                 .build();
         StringBuilder prompt = new StringBuilder(database + "::" + sessionType.name().toLowerCase() + "::" + transactionType.name().toLowerCase());
         if (options.isCluster() && options.asCluster().readAnyReplica().isPresent() && options.asCluster().readAnyReplica().get())

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -328,6 +328,40 @@ public class TypeDBConsole {
         return false;
     }
 
+    private boolean runUserList(TypeDBClient.Cluster client) {
+        try {
+            if (client.users().all().size() > 0)
+                client.users().all().forEach(user -> printer.info(user.name()));
+            else printer.info("No databases are present on the server.");
+            return true;
+        } catch (TypeDBClientException e) {
+            printer.error(e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean runUserCreate(TypeDBClient.Cluster client, String user, String password) {
+        try {
+            client.users().create(user, password);
+            printer.info("User '" + user + "' created");
+            return true;
+        } catch (TypeDBClientException e) {
+            printer.error(e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean runUserDelete(TypeDBClient.Cluster client, String user) {
+        try {
+            client.users().get(user).delete();
+            printer.info("User '" + user + "' deleted");
+            return true;
+        } catch (TypeDBClientException e) {
+            printer.error(e.getMessage());
+            return false;
+        }
+    }
+
     private boolean runDatabaseList(TypeDBClient client) {
         try {
             if (client.databases().all().size() > 0)

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -353,7 +353,7 @@ public class TypeDBConsole {
             TypeDBClient.Cluster clientCluster = client.asCluster();
             if (clientCluster.users().all().size() > 0)
                 clientCluster.users().all().forEach(user -> printer.info(user.name()));
-            else printer.info("No databases are present on the server.");
+            else printer.info("No users are present on the server.");
             return true;
         } catch (TypeDBClientException e) {
             printer.error(e.getMessage());

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -603,7 +603,7 @@ public class TypeDBConsole {
     }
 
     @CommandLine.Command(name = "typedb console", mixinStandardHelpOptions = true, version = {com.vaticle.typedb.console.Version.VERSION})
-    public static class CommandLineOptions implements Runnable {
+    private static class CommandLineOptions implements Runnable {
 
         @CommandLine.Option(names = {"--server"},
                 description = "TypeDB address to which Console will connect to")
@@ -680,39 +680,39 @@ public class TypeDBConsole {
         }
 
         @Nullable
-        public String server() {
+        private String server() {
             return server;
         }
 
         @Nullable
-        public String cluster() {
+        private String cluster() {
             return cluster;
         }
 
-        public String username() {
+        private String username() {
             return username;
         }
 
-        public String password() {
+        private String password() {
             return password;
         }
 
-        public boolean tlsEnabled() {
+        private boolean tlsEnabled() {
             return tlsEnabled;
         }
 
         @Nullable
-        public String tlsRootCA() {
+        private String tlsRootCA() {
             return tlsRootCA;
         }
 
         @Nullable
-        public String script() {
+        private String script() {
             return script;
         }
 
         @Nullable
-        public List<String> commands() {
+        private List<String> commands() {
             return commands;
         }
     }

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,6 +34,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
-        remote = "https://github.com/lolski/client-java",
-        commit = "6b2e41c5d9603b69b8dbda92ed91f617584c9435",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        remote = "https://github.com/vaticle/client-java",
+        commit = "94085b7d710ca9078056eec64f988279ce7201a8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/lolski/client-java",
-        commit = "a8a0ba707596d9070159729b0dd97d222a85fd73",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "92c5b9880214fc012cdeaa164b5367fa9f56ab6a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/lolski/client-java",
-        commit = "8541d0db93a925de6707760926abf8dd8700223a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "6b2e41c5d9603b69b8dbda92ed91f617584c9435",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/lolski/client-java",
-        commit = "8acbf9d580be34aaaaf87dd16a9c19d7835f883f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "8541d0db93a925de6707760926abf8dd8700223a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -1,4 +1,4 @@
-
+#
 # Copyright (C) 2021 Vaticle
 #
 # This program is free software: you can redistribute it and/or modify
@@ -35,5 +35,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/lolski/client-java",
-        commit = "92c5b9880214fc012cdeaa164b5367fa9f56ab6a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "8acbf9d580be34aaaaf87dd16a9c19d7835f883f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,6 +34,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
-        remote = "https://github.com/vaticle/typedb-client-java",
-        tag = "2.1.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        remote = "https://github.com/lolski/client-java",
+        commit = "a8a0ba707596d9070159729b0dd97d222a85fd73",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We have added authentication and user management support for to TypeDB Cluster.

## What are the changes implemented in this PR?

- Added `--username` and `--password` options. The options are validated such that they can only be supplied when connecting to TypeDB Cluster (it doesn't make sense to supply them when connecting to TypeDB which doesn't support authentication).
- Added the user management feature allowing users to manage user credentials:
  - `user create user1`
  - `user list`
  - `user delete user1`
