### PR TITLE
Improve handling password input

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -606,42 +606,52 @@ public class TypeDBConsole {
     @CommandLine.Command(name = "typedb console", mixinStandardHelpOptions = true, version = {com.vaticle.typedb.console.Version.VERSION})
     private static class CommandLineOptions implements Runnable {
 
-        @CommandLine.Option(names = {"--server"},
-                description = "TypeDB address to which Console will connect to")
+        @CommandLine.Option(
+                names = {"--server"},
+                description = "TypeDB address to which Console will connect to"
+        )
         private @Nullable
         String server;
 
-        @CommandLine.Option(names = {"--cluster"},
-                description = "TypeDB Cluster address to which Console will connect to")
+        @CommandLine.Option(
+                names = {"--cluster"},
+                description = "TypeDB Cluster address to which Console will connect to"
+        )
         private @Nullable
         String cluster;
 
-        @CommandLine.Option(names = {"--username"},
-                description = "Username")
+        @CommandLine.Option(names = {"--username"}, description = "Username")
         private @Nullable
         String username;
 
-        @CommandLine.Option(names = {"--password"},
-                description = "Password")
+        @CommandLine.Option(names = {"--password"}, description = "Password", interactive = true, arity = "0..1")
         private @Nullable
         String password;
 
-        @CommandLine.Option(names = {"--tls-enabled"},
-                description = "Whether to connect to TypeDB Cluster with TLS encryption")
+        @CommandLine.Option(
+                names = {"--tls-enabled"},
+                description = "Whether to connect to TypeDB Cluster with TLS encryption"
+        )
         private boolean tlsEnabled;
 
-        @CommandLine.Option(names = {"--tls-root-ca"},
-                description = "Path to the TLS root CA file")
+        @CommandLine.Option(
+                names = {"--tls-root-ca"},
+                description = "Path to the TLS root CA file"
+        )
         private @Nullable
         String tlsRootCA;
 
-        @CommandLine.Option(names = {"--script"},
-                description = "Script with commands to run in the Console, without interactive mode")
+        @CommandLine.Option(
+                names = {"--script"},
+                description = "Script with commands to run in the Console, without interactive mode"
+        )
         private @Nullable
         String script;
 
-        @CommandLine.Option(names = {"--command"},
-                description = "Commands to run in the Console, without interactive mode")
+        @CommandLine.Option(
+                names = {"--command"},
+                description = "Commands to run in the Console, without interactive mode"
+        )
         private @Nullable
         List<String> commands;
 

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -165,14 +165,14 @@ public class TypeDBConsole {
             while (true) {
                 REPLCommand command;
                 try {
-                    command = REPLCommand.getCommand(reader, printer, "> ", client.isCluster());
+                    command = REPLCommand.readREPLCommand(reader, printer, "> ", client.isCluster());
                 } catch (InterruptedException e) {
                     break;
                 }
                 if (command.isExit()) {
                     break;
                 } else if (command.isHelp()) {
-                    printer.info(REPLCommand.getHelpMenu(client));
+                    printer.info(REPLCommand.createHelpMenu(client));
                 } else if (command.isClear()) {
                     reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
                 } else if (command.isUserList()) {
@@ -226,7 +226,7 @@ public class TypeDBConsole {
             while (true) {
                 Either<TransactionREPLCommand, String> command;
                 try {
-                    command = TransactionREPLCommand.getCommand(reader, prompt.toString());
+                    command = TransactionREPLCommand.readCommand(reader, prompt.toString());
                 } catch (InterruptedException e) {
                     break;
                 }
@@ -240,7 +240,7 @@ public class TypeDBConsole {
                     } else if (replCommand.isClear()) {
                         reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
                     } else if (replCommand.isHelp()) {
-                        printer.info(TransactionREPLCommand.getHelpMenu());
+                        printer.info(TransactionREPLCommand.createHelpMenu());
                     } else if (replCommand.isCommit()) {
                         runCommit(tx);
                         break;
@@ -282,7 +282,7 @@ public class TypeDBConsole {
             for (; i < inlineCommands.size() && !cancelled[0]; i++) {
                 String commandString = inlineCommands.get(i);
                 printer.info("+ " + commandString);
-                REPLCommand command = REPLCommand.getCommand(commandString, null, client.isCluster());
+                REPLCommand command = REPLCommand.readREPLCommand(commandString, null, client.isCluster());
                 if (command != null) {
                     if (command.isUserList()) {
                         boolean success = runUserList(client);
@@ -322,7 +322,7 @@ public class TypeDBConsole {
                             for (i += 1; i < inlineCommands.size() && !cancelled[0]; i++) {
                                 String txCommandString = inlineCommands.get(i);
                                 printer.info("++ " + txCommandString);
-                                Either<TransactionREPLCommand, String> txCommand = TransactionREPLCommand.getCommand(txCommandString);
+                                Either<TransactionREPLCommand, String> txCommand = TransactionREPLCommand.readCommand(txCommandString);
                                 if (txCommand.isSecond()) {
                                     printer.error(txCommand.second());
                                     return false;

--- a/command/REPLCommand.java
+++ b/command/REPLCommand.java
@@ -616,7 +616,7 @@ public interface REPLCommand {
         }
     }
 
-    static String getHelpMenu(TypeDBClient client) {
+    static String createHelpMenu(TypeDBClient client) {
         List<Pair<String, String>> menu = new ArrayList<>();
         if (client.isCluster()) {
             menu.addAll(Arrays.asList(
@@ -644,14 +644,14 @@ public interface REPLCommand {
                 pair(Clear.helpCommand, Clear.description),
                 pair(Exit.helpCommand, Exit.description)
         ));
-        return Utils.buildHelpMenu(menu);
+        return Utils.createHelpMenu(menu);
     }
 
-    static REPLCommand getCommand(LineReader reader, Printer printer, String prompt, boolean isCluster) throws InterruptedException {
+    static REPLCommand readREPLCommand(LineReader reader, Printer printer, String prompt, boolean isCluster) throws InterruptedException {
         REPLCommand command = null;
         while (command == null) {
             String line = Utils.readNonEmptyLine(reader, prompt);
-            command = getCommand(line, reader, isCluster);
+            command = readREPLCommand(line, reader, isCluster);
             if (command == null) {
                 printer.error("Unrecognised command, please check help menu");
             }
@@ -660,7 +660,7 @@ public interface REPLCommand {
         return command;
     }
 
-    static REPLCommand getCommand(String line, @Nullable LineReader passwordReader, boolean isCluster) {
+    static REPLCommand readREPLCommand(String line, @Nullable LineReader passwordReader, boolean isCluster) {
         REPLCommand command = null;
         String[] tokens = Utils.splitLineByWhitespace(line);
         if (tokens.length == 1 && tokens[0].equals(Exit.token)) {
@@ -677,7 +677,7 @@ public interface REPLCommand {
             String password;
             if (tokens.length == 3) {
                 if (passwordReader == null) throw new TypeDBConsoleException(UNABLE_TO_READ_PASSWORD_INTERACTIVELY);
-                password = passwordReader.readLine('0');
+                password = Utils.readPassword(passwordReader, "Enter password:");
             } else {
                 password = tokens[3];
             }

--- a/command/TransactionREPLCommand.java
+++ b/command/TransactionREPLCommand.java
@@ -39,13 +39,13 @@ import static com.vaticle.typedb.console.common.exception.ErrorMessage.Transacti
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_ROLLBACK_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_SOURCE_ARGS;
 
-public interface TransactionReplCommand {
+public interface TransactionREPLCommand {
 
     default boolean isExit() {
         return false;
     }
 
-    default TransactionReplCommand.Exit asExit() {
+    default TransactionREPLCommand.Exit asExit() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -53,7 +53,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Help asHelp() {
+    default TransactionREPLCommand.Help asHelp() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -61,7 +61,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Clear asClear() {
+    default TransactionREPLCommand.Clear asClear() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -69,7 +69,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Commit asCommit() {
+    default TransactionREPLCommand.Commit asCommit() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -77,7 +77,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Rollback asRollback() {
+    default TransactionREPLCommand.Rollback asRollback() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -85,7 +85,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Close asClose() {
+    default TransactionREPLCommand.Close asClose() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -93,7 +93,7 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Source asSource() {
+    default TransactionREPLCommand.Source asSource() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
@@ -101,11 +101,11 @@ public interface TransactionReplCommand {
         return false;
     }
 
-    default TransactionReplCommand.Query asQuery() {
+    default TransactionREPLCommand.Query asQuery() {
         throw new TypeDBConsoleException(ILLEGAL_CAST);
     }
 
-    class Exit implements TransactionReplCommand {
+    class Exit implements TransactionREPLCommand {
 
         private static String token = "exit";
         private static String helpCommand = token;
@@ -118,12 +118,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Exit asExit() {
+        public TransactionREPLCommand.Exit asExit() {
             return this;
         }
     }
 
-    class Help implements TransactionReplCommand {
+    class Help implements TransactionREPLCommand {
 
         private static String token = "help";
         private static String helpCommand = token;
@@ -136,12 +136,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Help asHelp() {
+        public TransactionREPLCommand.Help asHelp() {
             return this;
         }
     }
 
-    class Clear implements TransactionReplCommand {
+    class Clear implements TransactionREPLCommand {
 
         private static String token = "clear";
         private static String helpCommand = token;
@@ -154,12 +154,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Clear asClear() {
+        public TransactionREPLCommand.Clear asClear() {
             return this;
         }
     }
 
-    class Commit implements TransactionReplCommand {
+    class Commit implements TransactionREPLCommand {
 
         private static String token = "commit";
         private static String helpCommand = token;
@@ -172,12 +172,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Commit asCommit() {
+        public TransactionREPLCommand.Commit asCommit() {
             return this;
         }
     }
 
-    class Rollback implements TransactionReplCommand {
+    class Rollback implements TransactionREPLCommand {
 
         private static String token = "rollback";
         private static String helpCommand = token;
@@ -190,12 +190,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Rollback asRollback() {
+        public TransactionREPLCommand.Rollback asRollback() {
             return this;
         }
     }
 
-    class Close implements TransactionReplCommand {
+    class Close implements TransactionREPLCommand {
 
         private static String token = "close";
         private static String helpCommand = token;
@@ -208,12 +208,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Close asClose() {
+        public TransactionREPLCommand.Close asClose() {
             return this;
         }
     }
 
-    class Source implements TransactionReplCommand {
+    class Source implements TransactionREPLCommand {
 
         private static String token = "source";
         private static String helpCommand = token + " <file>";
@@ -236,12 +236,12 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Source asSource() {
+        public TransactionREPLCommand.Source asSource() {
             return this;
         }
     }
 
-    class Query implements TransactionReplCommand {
+    class Query implements TransactionREPLCommand {
 
         private static String helpCommand = "<query>";
         private static String description = "Run TypeQL query";
@@ -262,28 +262,28 @@ public interface TransactionReplCommand {
         }
 
         @Override
-        public TransactionReplCommand.Query asQuery() {
+        public TransactionREPLCommand.Query asQuery() {
             return this;
         }
     }
 
     static String getHelpMenu() {
         List<Pair<String, String>> menu = Arrays.asList(
-                pair(TransactionReplCommand.Query.helpCommand, TransactionReplCommand.Query.description),
-                pair(TransactionReplCommand.Source.helpCommand, TransactionReplCommand.Source.description),
-                pair(TransactionReplCommand.Commit.helpCommand, TransactionReplCommand.Commit.description),
-                pair(TransactionReplCommand.Rollback.helpCommand, TransactionReplCommand.Rollback.description),
-                pair(TransactionReplCommand.Close.helpCommand, TransactionReplCommand.Close.description),
-                pair(TransactionReplCommand.Help.helpCommand, TransactionReplCommand.Help.description),
-                pair(TransactionReplCommand.Clear.helpCommand, TransactionReplCommand.Clear.description),
-                pair(TransactionReplCommand.Exit.helpCommand, TransactionReplCommand.Exit.description)
+                pair(TransactionREPLCommand.Query.helpCommand, TransactionREPLCommand.Query.description),
+                pair(TransactionREPLCommand.Source.helpCommand, TransactionREPLCommand.Source.description),
+                pair(TransactionREPLCommand.Commit.helpCommand, TransactionREPLCommand.Commit.description),
+                pair(TransactionREPLCommand.Rollback.helpCommand, TransactionREPLCommand.Rollback.description),
+                pair(TransactionREPLCommand.Close.helpCommand, TransactionREPLCommand.Close.description),
+                pair(TransactionREPLCommand.Help.helpCommand, TransactionREPLCommand.Help.description),
+                pair(TransactionREPLCommand.Clear.helpCommand, TransactionREPLCommand.Clear.description),
+                pair(TransactionREPLCommand.Exit.helpCommand, TransactionREPLCommand.Exit.description)
         );
         return Utils.buildHelpMenu(menu);
     }
 
-    static Either<TransactionReplCommand, String> getCommand(LineReader reader, String prompt) throws InterruptedException {
+    static Either<TransactionREPLCommand, String> getCommand(LineReader reader, String prompt) throws InterruptedException {
         String line = Utils.readNonEmptyLine(reader, prompt);
-        Either<TransactionReplCommand, String> command = getCommand(line);
+        Either<TransactionREPLCommand, String> command = getCommand(line);
         if (command.isSecond()) return command;
         else if (command.first().isQuery()) {
             String query = readMultilineQuery(reader, prompt, command.first().asQuery().query());
@@ -294,8 +294,8 @@ public interface TransactionReplCommand {
         return command;
     }
 
-    static Either<TransactionReplCommand, String> getCommand(String line) {
-        TransactionReplCommand command;
+    static Either<TransactionREPLCommand, String> getCommand(String line) {
+        TransactionREPLCommand command;
         String[] tokens = Utils.splitLineByWhitespace(line);
         if (tokens[0].equals(Exit.token)) {
             if (tokens.length - 1 != Exit.args) return Either.second(INVALID_EXIT_ARGS.message(Exit.args, tokens.length - 1));

--- a/command/TransactionREPLCommand.java
+++ b/command/TransactionREPLCommand.java
@@ -107,10 +107,10 @@ public interface TransactionREPLCommand {
 
     class Exit implements TransactionREPLCommand {
 
-        private static String token = "exit";
-        private static String helpCommand = token;
-        private static String description = "Exit console";
-        private static int args = 0;
+        private static final String token = "exit";
+        private static final String helpCommand = token;
+        private static final String description = "Exit console";
+        private static final int args = 0;
 
         @Override
         public boolean isExit() {
@@ -125,10 +125,10 @@ public interface TransactionREPLCommand {
 
     class Help implements TransactionREPLCommand {
 
-        private static String token = "help";
-        private static String helpCommand = token;
-        private static String description = "Print this help menu";
-        private static int args = 0;
+        private static final String token = "help";
+        private static final String helpCommand = token;
+        private static final String description = "Print this help menu";
+        private static final int args = 0;
 
         @Override
         public boolean isHelp() {
@@ -143,10 +143,10 @@ public interface TransactionREPLCommand {
 
     class Clear implements TransactionREPLCommand {
 
-        private static String token = "clear";
-        private static String helpCommand = token;
-        private static String description = "Clear console screen";
-        private static int args = 0;
+        private static final String token = "clear";
+        private static final String helpCommand = token;
+        private static final String description = "Clear console screen";
+        private static final int args = 0;
 
         @Override
         public boolean isClear() {
@@ -161,10 +161,10 @@ public interface TransactionREPLCommand {
 
     class Commit implements TransactionREPLCommand {
 
-        private static String token = "commit";
-        private static String helpCommand = token;
-        private static String description = "Commit the transaction changes and close transaction";
-        private static int args = 0;
+        private static final String token = "commit";
+        private static final String helpCommand = token;
+        private static final String description = "Commit the transaction changes and close transaction";
+        private static final int args = 0;
 
         @Override
         public boolean isCommit() {
@@ -179,10 +179,10 @@ public interface TransactionREPLCommand {
 
     class Rollback implements TransactionREPLCommand {
 
-        private static String token = "rollback";
-        private static String helpCommand = token;
-        private static String description = "Rollback the transaction to the beginning state";
-        private static int args = 0;
+        private static final String token = "rollback";
+        private static final String helpCommand = token;
+        private static final String description = "Rollback the transaction to the beginning state";
+        private static final int args = 0;
 
         @Override
         public boolean isRollback() {
@@ -197,10 +197,10 @@ public interface TransactionREPLCommand {
 
     class Close implements TransactionREPLCommand {
 
-        private static String token = "close";
-        private static String helpCommand = token;
-        private static String description = "Close the transaction without committing changes";
-        private static int args = 0;
+        private static final String token = "close";
+        private static final String helpCommand = token;
+        private static final String description = "Close the transaction without committing changes";
+        private static final int args = 0;
 
         @Override
         public boolean isClose() {
@@ -215,10 +215,10 @@ public interface TransactionREPLCommand {
 
     class Source implements TransactionREPLCommand {
 
-        private static String token = "source";
-        private static String helpCommand = token + " <file>";
-        private static String description = "Run TypeQL queries in file";
-        private static int args = 1;
+        private static final String token = "source";
+        private static final String helpCommand = token + " <file>";
+        private static final String description = "Run TypeQL queries in file";
+        private static final int args = 1;
 
         private final String file;
 
@@ -243,8 +243,8 @@ public interface TransactionREPLCommand {
 
     class Query implements TransactionREPLCommand {
 
-        private static String helpCommand = "<query>";
-        private static String description = "Run TypeQL query";
+        private static final String helpCommand = "<query>";
+        private static final String description = "Run TypeQL query";
 
         private final String query;
 
@@ -267,7 +267,7 @@ public interface TransactionREPLCommand {
         }
     }
 
-    static String getHelpMenu() {
+    static String createHelpMenu() {
         List<Pair<String, String>> menu = Arrays.asList(
                 pair(TransactionREPLCommand.Query.helpCommand, TransactionREPLCommand.Query.description),
                 pair(TransactionREPLCommand.Source.helpCommand, TransactionREPLCommand.Source.description),
@@ -278,12 +278,12 @@ public interface TransactionREPLCommand {
                 pair(TransactionREPLCommand.Clear.helpCommand, TransactionREPLCommand.Clear.description),
                 pair(TransactionREPLCommand.Exit.helpCommand, TransactionREPLCommand.Exit.description)
         );
-        return Utils.buildHelpMenu(menu);
+        return Utils.createHelpMenu(menu);
     }
 
-    static Either<TransactionREPLCommand, String> getCommand(LineReader reader, String prompt) throws InterruptedException {
+    static Either<TransactionREPLCommand, String> readCommand(LineReader reader, String prompt) throws InterruptedException {
         String line = Utils.readNonEmptyLine(reader, prompt);
-        Either<TransactionREPLCommand, String> command = getCommand(line);
+        Either<TransactionREPLCommand, String> command = readCommand(line);
         if (command.isSecond()) return command;
         else if (command.first().isQuery()) {
             String query = readMultilineQuery(reader, prompt, command.first().asQuery().query());
@@ -294,7 +294,7 @@ public interface TransactionREPLCommand {
         return command;
     }
 
-    static Either<TransactionREPLCommand, String> getCommand(String line) {
+    static Either<TransactionREPLCommand, String> readCommand(String line) {
         TransactionREPLCommand command;
         String[] tokens = Utils.splitLineByWhitespace(line);
         if (tokens[0].equals(Exit.token)) {

--- a/common/Utils.java
+++ b/common/Utils.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class Utils {
 
-    public static String buildHelpMenu(List<Pair<String, String>> menu) {
+    public static String createHelpMenu(List<Pair<String, String>> menu) {
         if (menu.isEmpty()) return "\n";
         int maxHelpCommandLength = menu.stream().map(x -> x.first().length()).max(Integer::compare).get();
         int spacingLength = 4;
@@ -70,6 +70,10 @@ public class Utils {
             }
         }
         return line;
+    }
+
+    public static String readPassword(LineReader passwordReader, String prompt) {
+        return passwordReader.readLine(prompt, (char) 0);
     }
 
     public static String getContinuationPrompt(String prompt) {

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -64,6 +64,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
     public static class Console extends ErrorMessage {
         public static final Console INCOMPATIBLE_JAVA_RUNTIME =
                 new Console(1, "Incompatible Java runtime version: '%s'. Please use Java 11 or above.");
+        public static final Console UNABLE_TO_READ_PASSWORD_INTERACTIVELY =
+                new Console(1, "Unable to read password interactively in non-interactive mode.");
 
         private static final String codePrefix = "CON";
         private static final String messagePrefix = "Invalid Console Operation";

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -31,7 +31,7 @@
 @maven//:commons_logging_commons_logging
 @maven//:commons_logging_commons_logging_1_2
 @maven//:info_picocli_picocli
-@maven//:info_picocli_picocli_4_3_2
+@maven//:info_picocli_picocli_4_6_1
 @maven//:io_cucumber_cucumber_core
 @maven//:io_cucumber_cucumber_core_5_1_3
 @maven//:io_cucumber_cucumber_expressions

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "515d6adf719cc7e78f9d313e6c97bce9f918b60b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "5f5e464effe0927a6cd61ad656ee03d521833294", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## What is the goal of this PR?

We've updated Console such that password input can be supplied interactively and non-interactively.

This is done primarily for security purpose, interactive input will be the preferred one since it is not stored in the CLI history. The non-interactive mode is still relevant and therefore supported, particularly for use in automation scripts and test.

Additionally, we've refactored the code to improve the terminologies. We used the word "Command" everywhere to refer to several different things which cause confusion. We've now made the terminologies more precise:
  - "CLI Options" is how we refer to the options specified when starting console (eg., `--username admin`)
  - "REPL command" is how we refer to the Console commands such as 'database create'
  - We've renamed the execution mode to be clear. Console has three modes of execution: "REPL mode", "script mode" and "inline command mode". The first mode is the interactive mode that most users will use. The second and the third mode are non-interactive and is suitable for use in automation scripts or tests.

## What are the changes implemented in this PR?

- Add support for interactive password input
- Refactored various names in the code
  - Improve the clarity of the different execution mode
  - Fix the fact that we really like the word "command" which is used everywhere
- Make non-final variables final whenever possible