### PR TITLE
Upgrade Java dependency for APT package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -169,7 +169,7 @@ assemble_apt(
     maintainer = "Vaticle <community@vaticle.com>",
     description = "TypeDB (console)",
     depends = [
-      "openjdk-8-jre",
+      "openjdk-11-jre",
       "typedb-bin (>=%{@vaticle_typedb_common})"
     ],
     workspace_refs = "@vaticle_typedb_console_workspace_refs//:refs.json",


### PR DESCRIPTION
## What is the goal of this PR?

Depend on Java 11 in APT package for consistency with TypeDB Server

## What are the changes implemented in this PR?

Depend on `openjdk-11-jre` for APT installations.