### PR TITLE
Fix APT package deployment

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -79,7 +79,7 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        # Do not upgrade Python until bazelbuild/rules_pkg#397 is fixed
         pyenv install 3.7.9
         pyenv global 3.7.9
         sudo unlink /usr/bin/python3
@@ -125,7 +125,7 @@ release:
         cat VERSION
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
-        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        # Do not upgrade Python until bazelbuild/rules_pkg#397 is fixed
         pyenv install 3.7.9
         pyenv global 3.7.9
         sudo unlink /usr/bin/python3

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -79,6 +79,12 @@ build:
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
 release:
   filter:
@@ -119,6 +125,12 @@ release:
         cat VERSION
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
+        # Downgrading Python is needed to work around bazelbuild/rules_pkg#397
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
         bazel run --define version=$(cat VERSION) //:deploy-apt -- release
     deploy-artifact-release:
       image: vaticle-ubuntu-20.04

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "f47caef7909c52116ff29881ff6671ee3e3b692f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4ee548cea883c716055566847c4736a7ef791c38", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## What is the goal of this PR?

Make APT package that we deploy installable again

## What are the changes implemented in this PR?

Use Python 3.7 version to run `deploy-apt-*` jobs to avoid bazelbuild/rules_pkg#397