### PR TITLE
Source command is quiet by default

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -603,17 +603,11 @@ public class TypeDBConsole {
         List<CompletableFuture<Void>> running = new ArrayList<>();
         for (TypeQLQuery query : queries) {
             if (query instanceof TypeQLDefine) {
-                QueryFuture<Void> defineFuture = tx.query().define(query.asDefine());
-                if (printAnswers) {
-                    defineFuture.get();
-                    printer.info("Concepts have been defined");
-                } else running.add(CompletableFuture.runAsync(defineFuture::get));
+                tx.query().define(query.asDefine()).get();
+                printer.info("Concepts have been defined");
             } else if (query instanceof TypeQLUndefine) {
-                QueryFuture<Void> undefineFuture = tx.query().undefine(query.asUndefine());
-                if (printAnswers) {
-                    undefineFuture.get();
-                    printer.info("Concepts have been undefined");
-                } else running.add(CompletableFuture.runAsync(undefineFuture::get));
+                tx.query().undefine(query.asUndefine()).get();
+                printer.info("Concepts have been undefined");
             } else if (query instanceof TypeQLInsert) {
                 Stream<ConceptMap> result = tx.query().insert(query.asInsert());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
@@ -634,7 +628,6 @@ public class TypeDBConsole {
                 else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch.Aggregate) {
                 QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
-                ;
                 if (printAnswers) printer.numeric(answerFuture.get());
                 else running.add(CompletableFuture.runAsync(answerFuture::get));
             } else if (query instanceof TypeQLMatch.Group) {

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -592,6 +592,7 @@ public class TypeDBConsole {
         }
     }
 
+    @SuppressWarnings("CheckReturnValue")
     private boolean runQuery(TypeDBTransaction tx, String queryString, boolean printAnswers) {
         List<TypeQLQuery> queries;
         try {
@@ -611,7 +612,7 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLInsert) {
                 Stream<ConceptMap> result = tx.query().insert(query.asInsert());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLDelete) {
                 QueryFuture<Void> deleteFuture = tx.query().delete(query.asDelete());
                 if (printAnswers) {
@@ -621,11 +622,11 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLUpdate) {
                 Stream<ConceptMap> result = tx.query().update(query.asUpdate());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch) {
                 Stream<ConceptMap> result = tx.query().match(query.asMatch());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch.Aggregate) {
                 QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
                 if (printAnswers) printer.numeric(answerFuture.get());
@@ -633,18 +634,18 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLMatch.Group) {
                 Stream<ConceptMapGroup> result = tx.query().match(query.asMatchGroup());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
-                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch.Group.Aggregate) {
                 Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
                 if (printAnswers) printCancellableResult(result, x -> printer.numericGroup(x, tx));
-                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLCompute) {
                 throw new TypeDBConsoleException("Compute query is not yet supported");
             } else {
                 throw new TypeDBConsoleException("Query is of unrecognized type: " + query);
             }
         }
-        CompletableFuture.allOf(running.toArray(new CompletableFuture[0]));
+        CompletableFuture.allOf(running.toArray(new CompletableFuture[0])).join();
         return true;
     }
 

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -310,7 +310,7 @@ public class TypeDBConsole {
                     } else if (replCommand.isSource()) {
                         runSource(tx, replCommand.asSource().file(), replCommand.asSource().printAnswers());
                     } else if (replCommand.isQuery()) {
-                        runQueriesPrint(tx, replCommand.asQuery().query());
+                        runQueriesPrintAnswers(tx, replCommand.asQuery().query());
                     }
                 }
             }
@@ -397,7 +397,7 @@ public class TypeDBConsole {
                                     boolean success = runSource(tx, source.file(), source.printAnswers());
                                     if (!success) return false;
                                 } else if (txCommand.first().isQuery()) {
-                                    boolean success = runQueriesPrint(tx, txCommand.first().asQuery().query());
+                                    boolean success = runQueriesPrintAnswers(tx, txCommand.first().asQuery().query());
                                     if (!success) return false;
                                 } else {
                                     printer.error("Command is not available while running console script.");
@@ -586,66 +586,31 @@ public class TypeDBConsole {
     private boolean runSource(TypeDBTransaction tx, String file, boolean printAnswers) {
         try {
             String queryString = new String(Files.readAllBytes(Paths.get(file)), StandardCharsets.UTF_8);
-            if (printAnswers) return runQueriesPrint(tx, queryString);
-            else return runQueriesNoPrint(tx, queryString);
+            if (printAnswers) return runQueriesPrintAnswers(tx, queryString);
+            else return runQueries(tx, queryString);
         } catch (IOException e) {
             printer.error("Failed to open file '" + file + "'");
             return false;
         }
     }
 
-    private boolean runQueriesPrint(TypeDBTransaction tx, String queryString) {
+    private boolean runQueries(TypeDBTransaction tx, String queryString) {
         Optional<List<TypeQLQuery>> queries = parseQueries(queryString);
         if (!queries.isPresent()) return false;
-        queries.get().forEach(query -> runQueryPrint(tx, query));
-        return true;
-    }
-
-    private boolean runQueriesNoPrint(TypeDBTransaction tx, String queryString) {
-        Optional<List<TypeQLQuery>> queries = parseQueries(queryString);
-        if (!queries.isPresent()) return false;
-        CompletableFuture.allOf(queries.get().stream().map(query -> runQueryNoPrint(tx, query))
+        CompletableFuture.allOf(queries.get().stream().map(query -> runQuery(tx, query))
                 .toArray(CompletableFuture[]::new)).join();
         return true;
     }
 
-    private void runQueryPrint(TypeDBTransaction tx, TypeQLQuery query) {
-        if (query instanceof TypeQLDefine) {
-            tx.query().define(query.asDefine()).get();
-            printer.info("Concepts have been defined");
-        } else if (query instanceof TypeQLUndefine) {
-            tx.query().undefine(query.asUndefine()).get();
-            printer.info("Concepts have been undefined");
-        } else if (query instanceof TypeQLInsert) {
-            Stream<ConceptMap> result = tx.query().insert(query.asInsert());
-            printCancellableResult(result, x -> printer.conceptMap(x, tx));
-        } else if (query instanceof TypeQLDelete) {
-            tx.query().delete(query.asDelete()).get();
-            printer.info("Concepts have been deleted");
-        } else if (query instanceof TypeQLUpdate) {
-            Stream<ConceptMap> result = tx.query().update(query.asUpdate());
-            printCancellableResult(result, x -> printer.conceptMap(x, tx));
-        } else if (query instanceof TypeQLMatch) {
-            Stream<ConceptMap> result = tx.query().match(query.asMatch());
-            printCancellableResult(result, x -> printer.conceptMap(x, tx));
-        } else if (query instanceof TypeQLMatch.Aggregate) {
-            QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
-            printer.numeric(answerFuture.get());
-        } else if (query instanceof TypeQLMatch.Group) {
-            Stream<ConceptMapGroup> result = tx.query().match(query.asMatchGroup());
-            printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
-        } else if (query instanceof TypeQLMatch.Group.Aggregate) {
-            Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
-            printCancellableResult(result, x -> printer.numericGroup(x, tx));
-        } else if (query instanceof TypeQLCompute) {
-            throw new TypeDBConsoleException("Compute query is not yet supported");
-        } else {
-            throw new TypeDBConsoleException("Query is of unrecognized type: " + query);
-        }
+    private boolean runQueriesPrintAnswers(TypeDBTransaction tx, String queryString) {
+        Optional<List<TypeQLQuery>> queries = parseQueries(queryString);
+        if (!queries.isPresent()) return false;
+        queries.get().forEach(query -> runQueryPrintAnswers(tx, query));
+        return true;
     }
 
     @SuppressWarnings("CheckReturnValue")
-    private CompletableFuture<Void> runQueryNoPrint(TypeDBTransaction tx, TypeQLQuery query) {
+    private CompletableFuture<Void> runQuery(TypeDBTransaction tx, TypeQLQuery query) {
         if (query instanceof TypeQLDefine) {
             tx.query().define(query.asDefine()).get();
             printer.info("Concepts have been defined");
@@ -675,6 +640,41 @@ public class TypeDBConsole {
         } else if (query instanceof TypeQLMatch.Group.Aggregate) {
             Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
             return CompletableFuture.runAsync(result::findFirst);
+        } else if (query instanceof TypeQLCompute) {
+            throw new TypeDBConsoleException("Compute query is not yet supported");
+        } else {
+            throw new TypeDBConsoleException("Query is of unrecognized type: " + query);
+        }
+    }
+
+    private void runQueryPrintAnswers(TypeDBTransaction tx, TypeQLQuery query) {
+        if (query instanceof TypeQLDefine) {
+            tx.query().define(query.asDefine()).get();
+            printer.info("Concepts have been defined");
+        } else if (query instanceof TypeQLUndefine) {
+            tx.query().undefine(query.asUndefine()).get();
+            printer.info("Concepts have been undefined");
+        } else if (query instanceof TypeQLInsert) {
+            Stream<ConceptMap> result = tx.query().insert(query.asInsert());
+            printCancellableResult(result, x -> printer.conceptMap(x, tx));
+        } else if (query instanceof TypeQLDelete) {
+            tx.query().delete(query.asDelete()).get();
+            printer.info("Concepts have been deleted");
+        } else if (query instanceof TypeQLUpdate) {
+            Stream<ConceptMap> result = tx.query().update(query.asUpdate());
+            printCancellableResult(result, x -> printer.conceptMap(x, tx));
+        } else if (query instanceof TypeQLMatch) {
+            Stream<ConceptMap> result = tx.query().match(query.asMatch());
+            printCancellableResult(result, x -> printer.conceptMap(x, tx));
+        } else if (query instanceof TypeQLMatch.Aggregate) {
+            QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
+            printer.numeric(answerFuture.get());
+        } else if (query instanceof TypeQLMatch.Group) {
+            Stream<ConceptMapGroup> result = tx.query().match(query.asMatchGroup());
+            printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
+        } else if (query instanceof TypeQLMatch.Group.Aggregate) {
+            Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
+            printCancellableResult(result, x -> printer.numericGroup(x, tx));
         } else if (query instanceof TypeQLCompute) {
             throw new TypeDBConsoleException("Compute query is not yet supported");
         } else {

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -29,6 +29,7 @@ import com.vaticle.typedb.client.api.answer.Numeric;
 import com.vaticle.typedb.client.api.answer.NumericGroup;
 import com.vaticle.typedb.client.api.connection.database.Database;
 import com.vaticle.typedb.client.api.connection.user.User;
+import com.vaticle.typedb.client.api.query.QueryFuture;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.common.collection.Either;
 import com.vaticle.typedb.common.util.Java;
@@ -73,6 +74,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -305,9 +307,9 @@ public class TypeDBConsole {
                         runClose(tx);
                         break;
                     } else if (replCommand.isSource()) {
-                        runSource(tx, replCommand.asSource().file());
+                        runSource(tx, replCommand.asSource().file(), replCommand.asSource().printAnswers());
                     } else if (replCommand.isQuery()) {
-                        runQuery(tx, replCommand.asQuery().query());
+                        runQuery(tx, replCommand.asQuery().query(), true);
                     }
                 }
             }
@@ -390,10 +392,11 @@ public class TypeDBConsole {
                                     runClose(tx);
                                     break;
                                 } else if (txCommand.first().isSource()) {
-                                    boolean success = runSource(tx, txCommand.first().asSource().file());
+                                    TransactionREPLCommand.Source source = txCommand.first().asSource();
+                                    boolean success = runSource(tx, source.file(), source.printAnswers());
                                     if (!success) return false;
                                 } else if (txCommand.first().isQuery()) {
-                                    boolean success = runQuery(tx, txCommand.first().asQuery().query());
+                                    boolean success = runQuery(tx, txCommand.first().asQuery().query(), true);
                                     if (!success) return false;
                                 } else {
                                     printer.error("Command is not available while running console script.");
@@ -579,17 +582,17 @@ public class TypeDBConsole {
         else printer.info("Transaction closed");
     }
 
-    private boolean runSource(TypeDBTransaction tx, String file) {
+    private boolean runSource(TypeDBTransaction tx, String file, boolean printAnswers) {
         try {
             String queryString = new String(Files.readAllBytes(Paths.get(file)), StandardCharsets.UTF_8);
-            return runQuery(tx, queryString);
+            return runQuery(tx, queryString, printAnswers);
         } catch (IOException e) {
             printer.error("Failed to open file '" + file + "'");
             return false;
         }
     }
 
-    private boolean runQuery(TypeDBTransaction tx, String queryString) {
+    private boolean runQuery(TypeDBTransaction tx, String queryString, boolean printAnswers) {
         List<TypeQLQuery> queries;
         try {
             queries = TypeQL.parseQueries(queryString).collect(toList());
@@ -597,40 +600,58 @@ public class TypeDBConsole {
             printer.error(e.getMessage());
             return false;
         }
+        List<CompletableFuture<Void>> running = new ArrayList<>();
         for (TypeQLQuery query : queries) {
             if (query instanceof TypeQLDefine) {
-                tx.query().define(query.asDefine()).get();
-                printer.info("Concepts have been defined");
+                QueryFuture<Void> defineFuture = tx.query().define(query.asDefine());
+                if (printAnswers) {
+                    defineFuture.get();
+                    printer.info("Concepts have been defined");
+                } else running.add(CompletableFuture.runAsync(defineFuture::get));
             } else if (query instanceof TypeQLUndefine) {
-                tx.query().undefine(query.asUndefine()).get();
-                printer.info("Concepts have been undefined");
+                QueryFuture<Void> undefineFuture = tx.query().undefine(query.asUndefine());
+                if (printAnswers) {
+                    undefineFuture.get();
+                    printer.info("Concepts have been undefined");
+                } else running.add(CompletableFuture.runAsync(undefineFuture::get));
             } else if (query instanceof TypeQLInsert) {
                 Stream<ConceptMap> result = tx.query().insert(query.asInsert());
-                printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLDelete) {
-                tx.query().delete(query.asDelete()).get();
-                printer.info("Concepts have been deleted");
+                QueryFuture<Void> deleteFuture = tx.query().delete(query.asDelete());
+                if (printAnswers) {
+                    deleteFuture.get();
+                    printer.info("Concepts have been deleted");
+                } else running.add(CompletableFuture.runAsync(deleteFuture::get));
             } else if (query instanceof TypeQLUpdate) {
                 Stream<ConceptMap> result = tx.query().update(query.asUpdate());
-                printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch) {
                 Stream<ConceptMap> result = tx.query().match(query.asMatch());
-                printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch.Aggregate) {
-                Numeric answer = tx.query().match(query.asMatchAggregate()).get();
-                printer.numeric(answer);
+                QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
+                ;
+                if (printAnswers) printer.numeric(answerFuture.get());
+                else running.add(CompletableFuture.runAsync(answerFuture::get));
             } else if (query instanceof TypeQLMatch.Group) {
                 Stream<ConceptMapGroup> result = tx.query().match(query.asMatchGroup());
-                printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
+                if (printAnswers) printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLMatch.Group.Aggregate) {
                 Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
-                printCancellableResult(result, x -> printer.numericGroup(x, tx));
+                if (printAnswers) printCancellableResult(result, x -> printer.numericGroup(x, tx));
+                else running.add(CompletableFuture.runAsync(result::findFirst));
             } else if (query instanceof TypeQLCompute) {
                 throw new TypeDBConsoleException("Compute query is not yet supported");
             } else {
                 throw new TypeDBConsoleException("Query is of unrecognized type: " + query);
             }
         }
+        CompletableFuture.allOf(running.toArray(new CompletableFuture[0]));
         return true;
     }
 

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -611,7 +611,7 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLInsert) {
                 Stream<ConceptMap> result = tx.query().insert(query.asInsert());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(result::findFirst));
+                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
             } else if (query instanceof TypeQLDelete) {
                 QueryFuture<Void> deleteFuture = tx.query().delete(query.asDelete());
                 if (printAnswers) {
@@ -621,11 +621,11 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLUpdate) {
                 Stream<ConceptMap> result = tx.query().update(query.asUpdate());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(result::findFirst));
+                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
             } else if (query instanceof TypeQLMatch) {
                 Stream<ConceptMap> result = tx.query().match(query.asMatch());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMap(x, tx));
-                else running.add(CompletableFuture.runAsync(result::findFirst));
+                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
             } else if (query instanceof TypeQLMatch.Aggregate) {
                 QueryFuture<Numeric> answerFuture = tx.query().match(query.asMatchAggregate());
                 if (printAnswers) printer.numeric(answerFuture.get());
@@ -633,11 +633,11 @@ public class TypeDBConsole {
             } else if (query instanceof TypeQLMatch.Group) {
                 Stream<ConceptMapGroup> result = tx.query().match(query.asMatchGroup());
                 if (printAnswers) printCancellableResult(result, x -> printer.conceptMapGroup(x, tx));
-                else running.add(CompletableFuture.runAsync(result::findFirst));
+                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
             } else if (query instanceof TypeQLMatch.Group.Aggregate) {
                 Stream<NumericGroup> result = tx.query().match(query.asMatchGroupAggregate());
                 if (printAnswers) printCancellableResult(result, x -> printer.numericGroup(x, tx));
-                else running.add(CompletableFuture.runAsync(result::findFirst));
+                else running.add(CompletableFuture.runAsync(() -> result.findFirst()));
             } else if (query instanceof TypeQLCompute) {
                 throw new TypeDBConsoleException("Compute query is not yet supported");
             } else {

--- a/command/TransactionREPLCommand.java
+++ b/command/TransactionREPLCommand.java
@@ -28,14 +28,17 @@ import org.jline.reader.UserInterruptException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static com.vaticle.typedb.common.collection.Collections.pair;
+import static com.vaticle.typedb.common.collection.Collections.set;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_CLEAR_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_CLOSE_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_COMMIT_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_EXIT_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_HELP_ARGS;
+import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_OPTIONAL_ARG;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_ROLLBACK_ARGS;
 import static com.vaticle.typedb.console.common.exception.ErrorMessage.TransactionRepl.INVALID_SOURCE_ARGS;
 
@@ -216,18 +219,25 @@ public interface TransactionREPLCommand {
     class Source implements TransactionREPLCommand {
 
         private static final String token = "source";
-        private static final String helpCommand = token + " <file>";
-        private static final String description = "Run TypeQL queries in file";
-        private static final int args = 1;
+        private static final String helpCommand = token + " <file> [--print-answers]";
+        private static final String description = "Run TypeQL queries in file.";
+        private static final Set<String> optionalArgs = set("--print-answers");
+        private static final Set<Integer> args = set(1, 2);
 
         private final String file;
+        private final boolean printAnswers;
 
-        public Source(String file) {
+        public Source(String file, boolean printAnswers) {
             this.file = file;
+            this.printAnswers = printAnswers;
         }
 
         public String file() {
             return file;
+        }
+
+        public boolean printAnswers() {
+            return printAnswers;
         }
 
         @Override
@@ -316,9 +326,17 @@ public interface TransactionREPLCommand {
             if (tokens.length - 1 != Close.args) return Either.second(INVALID_CLOSE_ARGS.message(Close.args, tokens.length - 1));
             command = new Close();
         } else if (tokens[0].equals(Source.token)) {
-            if (tokens.length - 1 != Source.args) return Either.second(INVALID_SOURCE_ARGS.message(Source.args, tokens.length - 1));
+            boolean printAnswers = false;
+            if (!Source.args.contains(tokens.length - 1)) {
+                return Either.second(INVALID_SOURCE_ARGS.message(Source.args, tokens.length - 1));
+            } else if (tokens.length == 3) {
+                String printAnswersArg = tokens[2];
+                if (!Source.optionalArgs.contains(printAnswersArg)) {
+                    return Either.second(INVALID_OPTIONAL_ARG.message(Source.token, printAnswersArg));
+                } else printAnswers = true;
+            }
             String file = tokens[1];
-            command = new Source(file);
+            command = new Source(file, printAnswers);
         } else {
             command = new Query(line);
         }

--- a/command/TransactionREPLCommand.java
+++ b/command/TransactionREPLCommand.java
@@ -222,7 +222,7 @@ public interface TransactionREPLCommand {
         private static final String helpCommand = token + " <file> [--print-answers]";
         private static final String description = "Run TypeQL queries in file.";
         private static final Set<String> optionalArgs = set("--print-answers");
-        private static final Set<Integer> args = set(1, 2);
+        private static final int mandatoryArgs = 1;
 
         private final String file;
         private final boolean printAnswers;
@@ -326,9 +326,10 @@ public interface TransactionREPLCommand {
             if (tokens.length - 1 != Close.args) return Either.second(INVALID_CLOSE_ARGS.message(Close.args, tokens.length - 1));
             command = new Close();
         } else if (tokens[0].equals(Source.token)) {
+            int args = tokens.length - 1;
             boolean printAnswers = false;
-            if (!Source.args.contains(tokens.length - 1)) {
-                return Either.second(INVALID_SOURCE_ARGS.message(Source.args, tokens.length - 1));
+            if (args < Source.mandatoryArgs || args > Source.mandatoryArgs + Source.optionalArgs.size()) {
+                return Either.second(INVALID_SOURCE_ARGS.message(Source.mandatoryArgs, Source.optionalArgs.size(), args));
             } else if (tokens.length == 3) {
                 String printAnswersArg = tokens[2];
                 if (!Source.optionalArgs.contains(printAnswersArg)) {

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -25,20 +25,22 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
 
     public static class TransactionRepl extends ErrorMessage {
 
+        public static final TransactionRepl INVALID_OPTIONAL_ARG =
+                new TransactionRepl(1, "'%s' does not have an optional argument '%s'.");
         public static final TransactionRepl INVALID_EXIT_ARGS =
-                new TransactionRepl(1, "'exit' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(2, "'exit' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_HELP_ARGS =
-                new TransactionRepl(2, "'help' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(3, "'help' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_CLEAR_ARGS =
-                new TransactionRepl(3, "'clear' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(4, "'clear' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_COMMIT_ARGS =
-                new TransactionRepl(4, "'commit' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(5, "'commit' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_ROLLBACK_ARGS =
-                new TransactionRepl(5, "'rollback' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(6, "'rollback' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_CLOSE_ARGS =
-                new TransactionRepl(6, "'close' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(7, "'close' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_SOURCE_ARGS =
-                new TransactionRepl(7, "'source' expects %s space-separated arguments, received %s.");
+                new TransactionRepl(8, "'source' expects any of %s space-separated arguments, received %s.");
 
         private static final String codePrefix = "TXN";
         private static final String messagePrefix = "Invalid Transaction command";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -40,7 +40,8 @@ public abstract class ErrorMessage extends com.vaticle.typedb.common.exception.E
         public static final TransactionRepl INVALID_CLOSE_ARGS =
                 new TransactionRepl(7, "'close' expects %s space-separated arguments, received %s.");
         public static final TransactionRepl INVALID_SOURCE_ARGS =
-                new TransactionRepl(8, "'source' expects any of %s space-separated arguments, received %s.");
+                new TransactionRepl(8, "'source' expects %s mandatory arguments and up to %s optional " +
+                        "arguments, received %s arguments.");
 
         private static final String codePrefix = "TXN";
         private static final String messagePrefix = "Invalid Transaction command";


### PR DESCRIPTION
## What is the goal of this PR?

We make the `source` command not use the pretty-printer or wait for results unless specified with the `--print-answers` flag, which is optional.

## What are the changes implemented in this PR?

* `source` now has an optional `--print-answers`
* when not printing answers, we execute all the queries in the query string as async queries, then wait for them all at the end
* define/undefine never are fully async, and ways do a get() on the query result.