### PR TITLE
UX improvements to transaction commits and concept deletion

### DIFF
--- a/RunQueriesResult.java
+++ b/RunQueriesResult.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2021 Vaticle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.vaticle.typedb.console;
 
 public class RunQueriesResult {

--- a/RunQueriesResult.java
+++ b/RunQueriesResult.java
@@ -1,0 +1,23 @@
+package com.vaticle.typedb.console;
+
+public class RunQueriesResult {
+    private final boolean success;
+    private final boolean hasChanges;
+
+    public RunQueriesResult(boolean success, boolean hasChanges) {
+        this.success = success;
+        this.hasChanges = hasChanges;
+    }
+
+    public static RunQueriesResult error() {
+        return new RunQueriesResult(false, false);
+    }
+
+    public boolean success() {
+        return success;
+    }
+
+    public boolean hasChanges() {
+        return hasChanges;
+    }
+}

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -684,15 +684,13 @@ public class TypeDBConsole {
                 printer.info("No concepts were matched");
             }
         } else if (query instanceof TypeQLUpdate) {
-            Stream<ConceptMap> matchResult = tx.query().match(query.asUpdate().match());
-            AtomicInteger answerCount = new AtomicInteger();
-            printCancellableResult(matchResult, x -> {
-                answerCount.getAndIncrement();
+            Stream<ConceptMap> result = tx.query().update(query.asUpdate());
+            AtomicBoolean changed = new AtomicBoolean(false);
+            printCancellableResult(result, x -> {
+                changed.set(true);
                 printer.conceptMap(x, tx);
             });
-            Stream<ConceptMap> result = tx.query().update(query.asUpdate());
-            printCancellableResult(result, x -> printer.conceptMap(x, tx));
-            if (answerCount.get() > 0) hasUncommittedChanges = true;
+            if (changed.get()) hasUncommittedChanges = true;
         } else if (query instanceof TypeQLMatch) {
             Stream<ConceptMap> result = tx.query().match(query.asMatch());
             printCancellableResult(result, x -> printer.conceptMap(x, tx));


### PR DESCRIPTION
## What is the goal of this PR?

We've added an indicator for uncommitted changes within a transaction. While you are in a transaction that has uncommitted changes, an asterisk (*) will now be displayed in the prompt.

Also, concept deletion is now more transparent; the number of concepts being deleted (or updated) is printed to the console now. This is particularly helpful for catching when there is a bug in the match query that might cause it to delete no concepts, or the wrong concepts.

## What are the changes implemented in this PR?

- Indicate uncommitted changes
- Print the number of concepts that are being deleted (or updated)

We chose to not add a confirmation prompt prior to deletion just yet, this is due to Console architecture making that too difficult for now. This is (still!) tracked in:
- #166 
