### PR TITLE
Allow TypeQL-style comments in scripts

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -678,7 +678,7 @@ public class TypeDBConsole {
             if (limitedCount > 0) {
                 tx.query().delete(query.asDelete()).get();
                 if (limitedCount == 20) printer.info("Deleted from 20+ matched answers");
-                else printer.info("Deleted from " + limitedCount + " matched answers");
+                else printer.info("Deleted from " + limitedCount + " matched answer(s)");
                 hasUncommittedChanges = true;
             } else {
                 printer.info("No concepts were matched");

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -343,10 +343,10 @@ public class TypeDBConsole {
         boolean[] cancelled = new boolean[]{false};
         terminal.handle(Terminal.Signal.INT, s -> cancelled[0] = true);
         try (TypeDBClient client = createTypeDBClient(options)) {
-            int i = 0;
-            for (; i < inlineCommands.size() && !cancelled[0]; i++) {
+            for (int i = 0; i < inlineCommands.size() && !cancelled[0]; i++) {
                 String commandString = inlineCommands.get(i);
                 printer.info("+ " + commandString);
+                if (commandString.startsWith("#")) continue;
                 REPLCommand command = REPLCommand.readREPLCommand(commandString, null, client.isCluster());
                 if (command != null) {
                     if (command.isUserList()) {


### PR DESCRIPTION
## What is the goal of this PR?

We've added support for TypeQL-style comments in scripts. So, for example, you can now pass the following file to `--script`:
```
# create the database
database create social_network
transaction social_network schema write
source social_network_schema.tql
commit
```

## What are the changes implemented in this PR?

- Fix pluralisation when deleting concepts
- Allow TQL-style comments in scripts (fixes #170)