### PR TITLE
Disable Jline backslash stripping

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -52,6 +52,7 @@ import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.DefaultParser;
 import org.jline.reader.impl.completer.StringsCompleter;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
@@ -276,6 +277,7 @@ public class TypeDBConsole {
     private boolean transactionREPL(TypeDBClient client, String database, TypeDBSession.Type sessionType, TypeDBTransaction.Type transactionType, TypeDBOptions options) {
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
+                .parser(new DefaultParser().escapeChars(null))
                 .variable(LineReader.HISTORY_FILE, TRANSACTION_HISTORY_FILE)
                 .build();
         StringBuilder promptBuilder = new StringBuilder(database + "::" + sessionType.name().toLowerCase() + "::" + transactionType.name().toLowerCase());


### PR DESCRIPTION
## What is the goal of this PR?

JLine line parser, which handles console's REPL, no longer swallows backslahes and other escape characters. 

Previously, this lead to unexpected behaviour:

```
tmp::data::write> insert $x "hello \" world" isa val;
                  
[TQL03] TypeQL Error: There is a syntax error at line 1:
insert $x "hello " world" isa val;
                   ^
mismatched input 'world' expecting {';', 'has'}
```

Now, JLine keeps all the escape characters in place and hands the query parsing to TypeQL:
```
tmp::data::write> insert $x "hello \" world" isa val;
                  
{ $x "hello \" world" isa val; }
```

## What are the changes implemented in this PR?

* Replace the set of escape characters that JLine swallows with an empty set