### PR TITLE
Bump dependencies, updated factory CI instructions

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -28,19 +28,19 @@ build:
       owner: vaticle
       branch: master
     build-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
            bazel run @vaticle_dependencies//tool/sonarcloud:code-analysis -- \
-           --project-key vaticle_typedb_console --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
+           --project-key vaticle_typedb_console --branch=$FACTORY_BRANCH --commit-id=$FACTORY_COMMIT
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -55,7 +55,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       dependencies: [build]
       command: |
@@ -71,7 +71,7 @@ build:
       filter:
         owner: vaticle
         branch: master
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       dependencies: [build]
       command: |
@@ -93,7 +93,7 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -102,39 +102,41 @@ release:
         bazel test //:release-validate-deps  --test_output=streamed
   deployment:
     deploy-github:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       type: foreground
       command: |
-        pyenv install -s 3.6.10
-        pyenv global 3.6.10 system
-        pip install certifi
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export PYENV_ROOT="/opt/pyenv"
+        pyenv install 3.7.9
+        pyenv global 3.7.9
+        sudo unlink /usr/bin/python3
+        sudo ln -s $(which python3) /usr/bin/python3
+        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
+        python3 -m pip install certifi
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         export NOTES_CREATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:create -- $GRABL_OWNER $GRABL_REPO $GRABL_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
+        bazel run @vaticle_dependencies//tool/release/notes:create -- $FACTORY_OWNER $FACTORY_REPO $FACTORY_COMMIT $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --define version=$(cat VERSION) //:deploy-github -- $FACTORY_COMMIT
     deploy-apt-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       type: foreground
       command: |
         export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
         export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        cat VERSION
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_VATICLE_PASSWORD
         # Do not upgrade Python until bazelbuild/rules_pkg#397 is fixed
+        export PYENV_ROOT="/opt/pyenv"
         pyenv install 3.7.9
         pyenv global 3.7.9
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.7.9/lib/python3.7/site-packages/lsb_release.py
-        bazel run --define version=$(cat VERSION) //:deploy-apt -- release
+        bazel run --define version=$(cat VERSION) //binary:deploy-apt -- release
     deploy-artifact-release:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       dependencies: [deploy-github]
       type: foreground
       command: |

--- a/BUILD
+++ b/BUILD
@@ -205,7 +205,7 @@ checkstyle_test(
     name = "checkstyle",
     include = glob([
         "*",
-        ".grabl/*",
+        ".factory/*",
         "command/*",
         "common/*",
         "common/exception/*",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeDB Console
 
-[![Grabl](https://grabl.io/api/status/vaticle/typedb-console/badge.svg)](https://grabl.io/vaticle/typedb-console)
+[![Factory](https://factory.vaticle.com/api/status/vaticle/typedb-console/badge.svg)](https://factory.vaticle.com/vaticle/typedb-console)
 [![GitHub release](https://img.shields.io/github/release/vaticle/typedb-console.svg)](https://github.com/vaticle/typedb-console/releases/latest)
 [![Discord](https://img.shields.io/discord/665254494820368395?color=7389D8&label=chat&logo=discord&logoColor=ffffff)](https://vaticle.com/discord)
 [![Discussion Forum](https://img.shields.io/discourse/https/forum.vaticle.com/topics.svg)](https://forum.vaticle.com)

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,19 +21,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        commit = "f0dd708adaea9fe1fdc3699180797a12166d33e8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        tag = "2.12.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/typedb-client-java",
-        commit = "5717b9cb0c63e0e1c4457ad8e5ad5141d3f04556",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        tag = "2.12.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We've bumped our dependencies and introduced updated instructions to Factory to facilitate the release of TypeDB 2.12.0. We've also updated our CI instructions to make use of Ubuntu 22.04 in line with our migration to Factory.

## What are the changes implemented in this PR?

We've fixed the Python version learned from the successful GitHub of typedb-common to a definite working version of Python for this job. 

We've also bumped our dependencies, fixing to the `2.12.0` tag for the upcoming release of TypeDB Console.
