### PR TITLE
Prompt a re-login when users change their own passwords

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -199,15 +199,23 @@ public class TypeDBConsole {
                     runUserCreate(client, command.asUserCreate().user(), command.asUserCreate().password());
                 } else if (command.isUserPasswordUpdate()) {
                     REPLCommand.User.PasswordUpdate userPasswordUpdate = command.asUserPasswordUpdate();
-                    runUserPasswordUpdate(client,
+                    boolean passwordUpdateSuccessful = runUserPasswordUpdate(client,
                             options.username,
                             userPasswordUpdate.passwordOld(),
                             userPasswordUpdate.passwordNew());
+                    if (passwordUpdateSuccessful) {
+                        printer.info("Please login again with your updated password.");
+                        break;
+                    }
                 } else if (command.isUserPasswordSet()) {
                     REPLCommand.User.PasswordSet userPasswordSet = command.asUserPasswordSet();
-                    runUserPasswordSet(client,
+                    boolean passwordSetSuccessful = runUserPasswordSet(client,
                             userPasswordSet.user(),
                             userPasswordSet.password());
+                    if (passwordSetSuccessful && userPasswordSet.user().equals(client.asCluster().user().username())) {
+                        printer.info("Please login again with your updated password.");
+                        break;
+                    }
                 } else if (command.isUserDelete()) {
                     runUserDelete(client, command.asUserDelete().user());
                 } else if (command.isDatabaseList()) {
@@ -526,7 +534,7 @@ public class TypeDBConsole {
             }
             TypeDBClient.Cluster clientCluster = client.asCluster();
             clientCluster.users().get(username).passwordUpdate(passwordOld, passwordNew);
-            printer.info("Updated password for user '" + username + "'");
+            printer.info("Updated password for user '" + username + "'.");
             return true;
         } catch (TypeDBClientException e) {
             printer.error(e.getMessage());

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_client_java():
     git_repository(
         name = "vaticle_typedb_client_java",
         remote = "https://github.com/vaticle/typedb-client-java",
-        tag = "2.16.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "45fc692b6a398579e034fe720a49bba508c3099f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

Console now quits upon a user changing their own password, rather than having a user be left in a session with invalid credentials (which they will only discover on running subsequent commands).

Fixes: #200 

## What are the changes implemented in this PR?

We've added checks to determine whether password sets and updates were successful, and if so, prompt the user to log in again before quitting.
