### PR TITLE
Change wording of password expiry warning

### DIFF
--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -467,7 +467,7 @@ public class TypeDBConsole {
                     Optional<Duration> passwordExpiry = client.asCluster().users().get(options.username)
                             .passwordExpirySeconds().map(Duration::ofSeconds);
                     if (passwordExpiry.isPresent() && passwordExpiry.get().compareTo(PASSWORD_EXPIRY_WARN) < 0) {
-                        printer.info("Your password will expire in " + passwordExpiry.get().toHours() + " hours.");
+                        printer.info("Your password will expire within " + (passwordExpiry.get().toHours() + 1) + " hour(s).");
                     }
                 } else {
                     client = TypeDB.coreClient(TypeDB.DEFAULT_ADDRESS);


### PR DESCRIPTION
## What is the goal of this PR?

We've changed the wording and logic of the password expiry warning to be more accurate.

This brings us in line with our implementation in Studio: https://github.com/vaticle/typedb-studio/pull/722

## What are the changes implemented in this PR?

To avoid returning "[...] will expire in 0 hours.", we now return "[...] will expire within 1 hour(s)." This is accurate and less jarring for users.

