### PR TITLE
Replace usages of 'client' and 'cluster' with 'driver' and 'enterprise' throughout

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,9 +42,9 @@ java_library(
     name = "console",
     srcs = glob(["*.java", "*/*.java", "*/*/*.java"], exclude=["bazel-*/*"]) + [":version"],
     deps = [
-        "@vaticle_typedb_client_java//java:client-java",
-        "@vaticle_typedb_client_java//java/api",
-        "@vaticle_typedb_client_java//java/common",
+        "@vaticle_typedb_driver//java:driver-java",
+        "@vaticle_typedb_driver//java/api",
+        "@vaticle_typedb_driver//java/common",
         "@vaticle_typeql//java:typeql-lang",
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/query",
@@ -196,7 +196,7 @@ release_validate_deps(
     tagged_deps = [
         "@vaticle_typedb_common",
         "@vaticle_typeql",
-        "@vaticle_typedb_client_java",
+        "@vaticle_typedb_driver",
     ],
     tags = ["manual"]  # in order for bazel test //... to not fail
 )

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ cd <your_typedb_console_dir>/
 You can provide several command arguments when running console in the terminal.
 
 - `--server=<address>` : TypeDB server address to which the console will connect to.
-- `--cluster=<address>` : TypeDB Cluster server address to which the console will connect to.
-- `--username=<username>` : TypeDB Cluster username to connect with.
-- `--password` : Interactively enter password to connect to TypeDB Cluster with.
+- `--enterprise=<address>` : TypeDB Enterprise server address to which the console will connect to.
+- `--username=<username>` : TypeDB Enterprise username to connect with.
+- `--password` : Interactively enter password to connect to TypeDB Enterprise with.
 - `--script=<script>` : Run commands in the script file in non-interactive mode.
-- `--tls-enabled`: Enable TLS for connecting to TypeDB Cluster.
+- `--tls-enabled`: Enable TLS for connecting to TypeDB Enterprise.
 - `--tls-root-ca`: Path to root CA certificate for TLS encryption.
 - `--command=<command1> --command=<command2> ...` : Run commands in non-interactive mode.
 - `-V, --version` : Print version information and exit.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -145,11 +145,11 @@ pip_deps()
 ################################
 
 # Load repositories
-load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typedb_client_java")
+load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typedb_driver")
 vaticle_typedb_common()
-vaticle_typedb_client_java()
+vaticle_typedb_driver()
 
-load("@vaticle_typedb_client_java//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol", "vaticle_typeql")
+load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol", "vaticle_typeql")
 vaticle_typeql()
 vaticle_typedb_protocol()
 
@@ -160,7 +160,7 @@ vaticle_typedb_artifact()
 # Load maven
 load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
-load("@vaticle_typedb_client_java//dependencies/maven:artifacts.bzl", vaticle_typedb_client_java_artifacts = "artifacts")
+load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
 load("@vaticle_typedb_console//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "artifacts")
 
 ###############
@@ -171,7 +171,7 @@ load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
     vaticle_typedb_common_artifacts +
     vaticle_typeql_artifacts +
-    vaticle_typedb_client_java_artifacts +
+    vaticle_typedb_driver_artifacts +
     vaticle_typedb_console_artifacts +
     vaticle_dependencies_tool_maven_artifacts +
     io_grpc_artifacts,

--- a/common/Printer.java
+++ b/common/Printer.java
@@ -17,19 +17,19 @@
 
 package com.vaticle.typedb.console.common;
 
-import com.vaticle.typedb.client.api.TypeDBTransaction;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
-import com.vaticle.typedb.client.api.answer.ConceptMapGroup;
-import com.vaticle.typedb.client.api.answer.Numeric;
-import com.vaticle.typedb.client.api.answer.NumericGroup;
-import com.vaticle.typedb.client.api.concept.Concept;
-import com.vaticle.typedb.client.api.concept.thing.Attribute;
-import com.vaticle.typedb.client.api.concept.thing.Relation;
-import com.vaticle.typedb.client.api.concept.thing.Thing;
-import com.vaticle.typedb.client.api.concept.type.RoleType;
-import com.vaticle.typedb.client.api.concept.type.Type;
-import com.vaticle.typedb.client.api.concept.value.Value;
-import com.vaticle.typedb.client.api.database.Database;
+import com.vaticle.typedb.driver.api.TypeDBTransaction;
+import com.vaticle.typedb.driver.api.answer.ConceptMap;
+import com.vaticle.typedb.driver.api.answer.ConceptMapGroup;
+import com.vaticle.typedb.driver.api.answer.Numeric;
+import com.vaticle.typedb.driver.api.answer.NumericGroup;
+import com.vaticle.typedb.driver.api.concept.Concept;
+import com.vaticle.typedb.driver.api.concept.thing.Attribute;
+import com.vaticle.typedb.driver.api.concept.thing.Relation;
+import com.vaticle.typedb.driver.api.concept.thing.Thing;
+import com.vaticle.typedb.driver.api.concept.type.RoleType;
+import com.vaticle.typedb.driver.api.concept.type.Type;
+import com.vaticle.typedb.driver.api.concept.value.Value;
+import com.vaticle.typedb.driver.api.database.Database;
 import com.vaticle.typedb.console.common.exception.TypeDBConsoleException;
 import com.vaticle.typeql.lang.common.TypeQLToken;
 import org.jline.utils.AttributedString;

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -27,8 +27,8 @@ def vaticle_dependencies():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "d3bd8b0813ce24a4ebe974a43801e431e20c69e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        tag = "2.24.1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -27,13 +27,13 @@ def vaticle_dependencies():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "40f8ab74b34447b59517ce3f027c8700a8aa057a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "d3bd8b0813ce24a4ebe974a43801e431e20c69e6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-driver-java",
-        commit = "c9f39aa628ac5eb9d20e46018bf97685587d936a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        remote = "https://github.com/vaticle/typedb-driver",
+        commit = "8c410a4a1332875b79333457ff63d5cf80861989",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -31,9 +31,9 @@ def vaticle_typedb_common():
         commit = "40f8ab74b34447b59517ce3f027c8700a8aa057a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
-def vaticle_typedb_client_java():
+def vaticle_typedb_driver():
     git_repository(
-        name = "vaticle_typedb_client_java",
+        name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver-java",
-        commit = "c9f39aa628ac5eb9d20e46018bf97685587d936a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_client_java
+        commit = "c9f39aa628ac5eb9d20e46018bf97685587d936a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )


### PR DESCRIPTION
## What is the goal of this PR?

We replace the term 'cluster' with 'enterprise', to reflect the new consistent terminology used through Vaticle. We also replace 'client' with 'driver', where appropriate.

## What are the changes implemented in this PR?

* Update REPL, README and code to no longer refer to TypeDB 'Clients', and use the new terminology of TypeDB 'Drivers', and replace usage of TypeDB 'Cluster' with TypeDB 'Enterprise'