### PR TITLE
Deploy apt amd64 with correct architecture tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ workflows:
       - deploy-apt-snapshot-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, platform-specific-releases]
       - deploy-apt-snapshot-arm64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,31 +289,31 @@ workflows:
       - deploy-artifact-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-artifact-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-apt-snapshot-x86_64:
           filters:
             branches:
-              only: [master, development, platform-specific-releases]
+              only: master
       - deploy-apt-snapshot-arm64:
           filters:
             branches:
-              only: [ master, development, platform-specific-releases ]
+              only: master
   release:
     jobs:
       - deploy-artifact-release-linux-x86_64:

--- a/BUILD
+++ b/BUILD
@@ -201,7 +201,7 @@ assemble_apt(
     empty_dirs = [
          "opt/typedb/core/console/lib/",
     ],
-    architecture = "x86_64",
+    architecture = "amd64",
     target_compatible_with = constraint_linux_x86_64,
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

`apt` expects the architecture tag for x86_64 to be `amd64`. 