### PR TITLE
Update command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd <your_typedb_console_dir>/
 
 You can provide several command arguments when running console in the terminal.
 
-- `--server=<address>` : TypeDB server address to which the console will connect to.
+- `--core=<address>` : TypeDB server address to which the console will connect to.
 - `--enterprise=<address>` : TypeDB Enterprise server address to which the console will connect to.
 - `--username=<username>` : TypeDB Enterprise username to connect with.
 - `--password` : Interactively enter password to connect to TypeDB Enterprise with.

--- a/TypeDBConsole.java
+++ b/TypeDBConsole.java
@@ -457,8 +457,8 @@ public class TypeDBConsole {
     private TypeDBDriver createTypeDBDriver(CLIOptions options) {
         TypeDBDriver driver = null;
         try {
-            if (options.server() != null) {
-                driver = TypeDB.coreDriver(options.server());
+            if (options.core() != null) {
+                driver = TypeDB.coreDriver(options.core());
             } else {
                 String optEnterprise = options.enterprise();
                 if (optEnterprise != null) {
@@ -818,11 +818,11 @@ public class TypeDBConsole {
     private static class CLIOptions implements Runnable {
 
         @CommandLine.Option(
-                names = {"--server"},
-                description = "TypeDB address to which Console will connect to"
+                names = {"--core"},
+                description = "TypeDB Core address to which Console will connect to"
         )
         private @Nullable
-        String server;
+        String core;
 
         @CommandLine.Option(
                 names = {"--enterprise"},
@@ -884,8 +884,8 @@ public class TypeDBConsole {
         }
 
         private void validateOptions() {
-            if (server != null && enterprise != null) {
-                throw new CommandLine.ParameterException(spec.commandLine(), "Either '--server' or '--enterprise' must be provided, but not both.");
+            if (core != null && enterprise != null) {
+                throw new CommandLine.ParameterException(spec.commandLine(), "Either '--core' or '--enterprise' must be provided, but not both.");
             } else {
                 if (enterprise != null) validateEnterpriseOptions();
                 else validateServerOptions();
@@ -913,8 +913,8 @@ public class TypeDBConsole {
         }
 
         @Nullable
-        private String server() {
-            return server;
+        private String core() {
+            return core;
         }
 
         @Nullable

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/vaticle/typedb-common",
-        tag = "2.25.3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "a338f2aec875f9e1a2578e803d0e7f2a92c6623d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():

--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -34,7 +34,7 @@ public class AssemblyTest {
         TypeDBCoreRunner coreRunner = new TypeDBCoreRunner();
         try {
             coreRunner.start();
-            int status = consoleRunner.run("--server", coreRunner.address(), "--command", "database create assembly-test-db");
+            int status = consoleRunner.run("--core", coreRunner.address(), "--command", "database create assembly-test-db");
             if (status != 0) {
                fail("Console command returned non-zero exit status: " + status);
             }


### PR DESCRIPTION
## What is the goal of this PR?

We update the CLI options to use the more distinct `--core` flag for connecting to the core server, mirroring `--enterprise`.

Connecting to TypeDB Core:
```
typedb console --core=<address>
```
Connecting to TypeDB Enterprise (unchanged):
```
typedb console --enterprise=<address> --username=<username> --password --tls-enabled
```

See https://github.com/vaticle/typedb/issues/6942 for full details.

We also improve the UX of the windows version of the entry point. Console no longer opens in a new window, but rather begins the REPL in the current command line window.