### PR TITLE
Replace all instances of 'enterprise' with 'cloud'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ cd <your_typedb_console_dir>/
 You can provide several command arguments when running console in the terminal.
 
 - `--core=<address>` : TypeDB server address to which the console will connect to.
-- `--enterprise=<address>` : TypeDB Enterprise server address to which the console will connect to.
-- `--username=<username>` : TypeDB Enterprise username to connect with.
-- `--password` : Interactively enter password to connect to TypeDB Enterprise with.
+- `--cloud=<address>` : TypeDB Cloud server address to which the console will connect to.
+- `--username=<username>` : TypeDB Cloud username to connect with.
+- `--password` : Interactively enter password to connect to TypeDB Cloud with.
 - `--script=<script>` : Run commands in the script file in non-interactive mode.
-- `--tls-enabled`: Enable TLS for connecting to TypeDB Enterprise.
+- `--tls-enabled`: Enable TLS for connecting to TypeDB Cloud.
 - `--tls-root-ca`: Path to root CA certificate for TLS encryption.
 - `--command=<command1> --command=<command2> ...` : Run commands in non-interactive mode.
 - `-V, --version` : Print version information and exit.

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,6 +34,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-driver",
-        tag = "2.25.7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        remote = "https://github.com/dmitrii-ubskii/typedb-driver",
+        commit = "88ad42c8f38f454c938ffe5f0fb77b9be61f219f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,19 +21,19 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "7e3ccaf030c45b3d2f30f804faafed68f02cb989",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "1200b4aef118e75ca070c4944e9459b2aab7982a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "a338f2aec875f9e1a2578e803d0e7f2a92c6623d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/dmitrii-ubskii/typedb-common",
+        commit = "40d7abaa956612addf4430b4d4685a20596333c9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/dmitrii-ubskii/typedb-driver",
-        commit = "88ad42c8f38f454c938ffe5f0fb77b9be61f219f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        commit = "85f0dce6e87eed4b1b4c236da61979234a250481",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -27,13 +27,13 @@ def vaticle_dependencies():
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "aeee242969199d2d33340288cc10aa0bf7ad857d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "4d2adde1cb75a40ca1629eed258d2a7dcda9f5e3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/dmitrii-ubskii/typedb-driver",
-        commit = "85f0dce6e87eed4b1b4c236da61979234a250481",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        remote = "https://github.com/vaticle/typedb-driver",
+        commit = "927343bbb09ad12ba74d88c94d443f3f81cc2e09",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -28,7 +28,7 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/dmitrii-ubskii/typedb-common",
-        commit = "40d7abaa956612addf4430b4d4685a20596333c9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "aeee242969199d2d33340288cc10aa0bf7ad857d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():


### PR DESCRIPTION
## What is the goal of this PR?

We replace the term 'enterprise' with 'cloud', to reflect the new consistent terminology used throughout Vaticle. In particular, this means that to connect to a Cloud instance (previously Enterprise), `typedb console --cloud <address>` replaces `typedb console --enterprise <address>`.