### PR TITLE
Reconfigure CircleCI executors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,5 +18,9 @@
 try-import ./.bazel-remote-cache.rc
 
 build --incompatible_strict_action_env --java_language_version=11 --javacopt='--release 11' --enable_runfiles
+# Don't depend on a JAVA_HOME pointing at a system JDK
+# see https://github.com/bazelbuild/rules_jvm_external/issues/445
+build --repo_env=JAVA_HOME=../bazel_tools/jdk
+
 run --incompatible_strict_action_env --java_runtime_version=remotejdk_11
 test --incompatible_strict_action_env --java_runtime_version=remotejdk_11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,12 @@ executors:
     resource_class: large
     working_directory: ~/typedb-console
 
+  linux-x86_64-ubuntu-1804:
+    docker:
+      - image: ubuntu:22.04
+    resource_class: large
+    working_directory: ~/typedb-console
+
   mac-arm64:
     macos:
       xcode: "13.4.1"
@@ -46,7 +52,7 @@ executors:
 
 
 commands:
-  install-bazel-linux:
+  install-bazel-yum:
     parameters:
       arch:
         type: string
@@ -59,7 +65,20 @@ commands:
           mv "bazelisk-linux-<<parameters.arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
 
-  install-bazel-mac:
+  install-bazel-apt:
+    parameters:
+      arch:
+        type: string
+    steps:
+      - run: |
+          apt-get -y update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+          apt-get -y install curl build-essential git python3 python3-pip default-jre lsof cmake file wget
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.arch>>"
+          mv "bazelisk-linux-<<parameters.arch>>" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/baze
+
+  install-bazel-brew:
     steps:
       - run: brew install bazelisk
 
@@ -68,7 +87,7 @@ jobs:
     executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-linux:
+      - install-bazel-yum:
           arch: amd64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -79,7 +98,7 @@ jobs:
     executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-linux:
+      - install-bazel-yum:
           arch: arm64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -90,7 +109,7 @@ jobs:
     executor: mac-x86_64
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -100,7 +119,7 @@ jobs:
     executor: mac-arm64
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -121,7 +140,7 @@ jobs:
     executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-linux:
+      - install-bazel-yum:
           arch: amd64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -138,7 +157,7 @@ jobs:
     executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
-      - install-bazel-linux:
+      - install-bazel-yum:
           arch: arm64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
@@ -155,7 +174,7 @@ jobs:
     executor: mac-x86_64
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -171,7 +190,7 @@ jobs:
     executor: mac-arm64
     steps:
       - checkout
-      - install-bazel-mac
+      - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
@@ -198,12 +217,12 @@ jobs:
           paths: [ "./*" ]
 
   deploy-github:
-    executor: linux-x86_64-amazonlinux-2
+    executor: linux-x86_64-ubuntu-1804
     steps:
       - attach_workspace:
           at: ~/dist
       - checkout
-      - install-bazel-linux:
+      - install-bazel-apt:
           arch: amd64
       - run:
           name: "Publish Release on GitHub"
@@ -215,7 +234,7 @@ jobs:
               -c ${CIRCLE_SHA1} -delete  $(cat VERSION) ~/dist/
 
   release-cleanup:
-    executor: linux-x86_64-amazonlinux-2
+    executor: linux-x86_64-ubuntu-1804
     steps:
       - checkout
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,23 +230,23 @@ workflows:
       - deploy-artifact-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, reconfigure-circleci-executors]
+              only: [master]
       - deploy-artifact-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, reconfigure-circleci-executors]
+              only: [master]
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, reconfigure-circleci-executors]
+              only: [master]
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, reconfigure-circleci-executors]
+              only: [master]
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, reconfigure-circleci-executors]
+              only: [master]
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,18 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.0.0
+  win: circleci/windows@5.0.0
 
 executors:
-  linux-arm64:
+  linux-arm64-amazonlinux-2:
     docker:
-      - image: ubuntu:18.04
+      - image: amazonlinux:2
     resource_class: arm.large
     working_directory: ~/typedb-console
 
-  linux-x86_64:
+  linux-x86_64-amazonlinux-2:
     docker:
-      - image: ubuntu:18.04
+      - image: amazonlinux:2
     resource_class: large
     working_directory: ~/typedb-console
 
@@ -52,9 +52,9 @@ commands:
         type: string
     steps:
       - run: |
-          apt-get -y update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
-          apt-get -y install curl build-essential git python3 python3-pip default-jre lsof cmake file wget
+          amazon-linux-extras install python3.8 -y
+          yum install -y git tar java-1.8.0-openjdk gcc gcc-c++ file lsof which procps
+          ln -s /usr/bin/python3.8 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.arch>>"
           mv "bazelisk-linux-<<parameters.arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -65,7 +65,7 @@ commands:
 
 jobs:
   deploy-artifact-snapshot-linux-x86_64:
-    executor: linux-x86_64
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -76,7 +76,7 @@ jobs:
           bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
 
   deploy-artifact-snapshot-linux-arm64:
-    executor: linux-arm64
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -110,6 +110,7 @@ jobs:
     executor:
       name: win/default
       shell: cmd.exe
+      size: large
     working_directory: ~/typedb-driver
     steps:
       - checkout
@@ -117,7 +118,7 @@ jobs:
       - run: .circleci\windows\deploy_snapshot.bat
 
   deploy-artifact-release-linux-x86_64:
-    executor: linux-x86_64
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -134,7 +135,7 @@ jobs:
           paths: ["./*"]
 
   deploy-artifact-release-linux-arm64:
-    executor: linux-arm64
+    executor: linux-arm64-amazonlinux-2
     steps:
       - checkout
       - install-bazel-linux:
@@ -186,6 +187,7 @@ jobs:
     executor:
       name: win/default
       shell: cmd.exe
+      size: large
     working_directory: ~/typedb-driver
     steps:
       - checkout
@@ -196,7 +198,7 @@ jobs:
           paths: [ "./*" ]
 
   deploy-github:
-    executor: linux-x86_64
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - attach_workspace:
           at: ~/dist
@@ -213,7 +215,7 @@ jobs:
               -c ${CIRCLE_SHA1} -delete  $(cat VERSION) ~/dist/
 
   release-cleanup:
-    executor: linux-x86_64
+    executor: linux-x86_64-amazonlinux-2
     steps:
       - checkout
       - run: |
@@ -228,23 +230,23 @@ workflows:
       - deploy-artifact-snapshot-linux-x86_64:
           filters:
             branches:
-              only: master
+              only: [master, reconfigure-circleci-executors]
       - deploy-artifact-snapshot-linux-arm64:
           filters:
             branches:
-              only: master
+              only: [master, reconfigure-circleci-executors]
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: master
+              only: [master, reconfigure-circleci-executors]
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:
-              only: master
+              only: [master, reconfigure-circleci-executors]
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: master
+              only: [master, reconfigure-circleci-executors]
 
   release:
     jobs:

--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -18,6 +18,6 @@
 
 <packages>
     <package id="bazelisk" version="1.17.0"/>
-    <package id="python" version="3.9.6"/>
+    <package id="python" version="3.11.0"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -26,12 +26,13 @@ REM install dependencies needed for build
 choco install .circleci\windows\dependencies.config  --limit-output --yes --no-progress
 
 REM create a symlink python3.exe and make it available in %PATH%
-mklink C:\Python39\python3.exe C:\Python39\python.exe
-set PATH=%PATH%;C:\Python39
+mklink C:\Python311\python3.exe C:\Python311\python.exe
+set PATH=%PATH%;C:\Python311
 
 REM install runtime dependency for the build
-C:\Python39\python.exe -m pip install wheel
+C:\Python311\python.exe -m pip install wheel
 
 REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
-SETX BAZEL_PYTHON C:\Python39\python.exe
+SETX BAZEL_PYTHON C:\Python311\python.exe
+SETX BAZEL_VC "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC"


### PR DESCRIPTION
## Usage and product changes

We compile and release TypeDB Console using an older version of Linux, which requires GLIBC 2.26 instead of GLIBC 2.27. This change switches the build platform to Amazon Linux 2 (via Docker), which is based on CentOS, instead of Ubuntu 18.04, which is based on Debian.

Additionally, we upgrade the Windows Orb to 5.0.0, which also allowed using a larger executor to reduce CI time.

## Implementation

- Migrate to `amazonlinux:2` docker for Linux builds
  - We migrate package installation and dependency management for build steps to use `yum`/`rpm` package management
- Migrate windows orb to `5.0.0`, and set executor to 'large'
  - We update the Python and VC installation parameters as required
