### PR TITLE
Migrate artifact hosting to cloudsmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,8 +90,8 @@ jobs:
       - install-bazel-yum:
           arch: amd64
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-x86_64-targz -- snapshot
 
   deploy-artifact-snapshot-linux-arm64:
@@ -101,8 +101,8 @@ jobs:
       - install-bazel-yum:
           arch: arm64
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
 
   deploy-artifact-snapshot-mac-x86_64:
@@ -111,8 +111,8 @@ jobs:
       - checkout
       - install-bazel-brew
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-x86_64-zip -- snapshot
 
   deploy-artifact-snapshot-mac-arm64:
@@ -121,8 +121,8 @@ jobs:
       - checkout
       - install-bazel-brew
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
 
   deploy-artifact-snapshot-windows-x86_64:
@@ -143,8 +143,8 @@ jobs:
       - install-bazel-yum:
           arch: amd64
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
       - run: |
           mkdir -p ~/dist
@@ -160,8 +160,8 @@ jobs:
       - install-bazel-yum:
           arch: arm64
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- release
       - run: |
           mkdir -p ~/dist
@@ -176,8 +176,8 @@ jobs:
       - checkout
       - install-bazel-brew
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-mac-x86_64-zip --compilation_mode=opt -- release
       - run: |
           mkdir -p ~/dist
@@ -192,8 +192,8 @@ jobs:
       - checkout
       - install-bazel-brew
       - run: |
-          export DEPLOY_ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-          export DEPLOY_ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+          export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-mac-arm64-zip --compilation_mode=opt -- release
       - run: |
           mkdir -p ~/dist

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -21,8 +21,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 SET /p VER=<VERSION
 bazel --output_user_root=C:/b run --verbose_failures --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- release

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -21,8 +21,8 @@ REM by Chocolatey in prepare.bat is accessible
 CALL refreshenv
 
 ECHO Building and deploying windows package...
-SET DEPLOY_ARTIFACT_USERNAME=%REPO_VATICLE_USERNAME%
-SET DEPLOY_ARTIFACT_PASSWORD=%REPO_VATICLE_PASSWORD%
+SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
+SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -36,8 +36,8 @@ build:
       image: vaticle-ubuntu-22.04
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel build //...
@@ -75,8 +75,8 @@ release:
       image: vaticle-ubuntu-22.04
       type: foreground
       command: |
-        export ARTIFACT_USERNAME=$REPO_VATICLE_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_VATICLE_PASSWORD
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         bazel test //:release-validate-deps  --test_output=streamed
     validate-release-notes:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -62,8 +62,8 @@ build:
       image: vaticle-ubuntu-22.04
       dependencies: [build]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
 
 release:
@@ -98,6 +98,6 @@ release:
       image: vaticle-ubuntu-22.04
       dependencies: [build]
       command: |
-        export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
-        export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD
+        export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
+        export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(cat VERSION) //tool/runner:deploy-maven -- release

--- a/BUILD
+++ b/BUILD
@@ -136,7 +136,7 @@ assemble_zip(
 deploy_artifact(
     name = "deploy-linux-x86_64-targz",
     target = ":assemble-linux-x86_64-targz",
-    artifact_group = "vaticle_typedb_console",
+    artifact_group = "typedb-console-linux-x86_64",
     artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
@@ -146,7 +146,7 @@ deploy_artifact(
 deploy_artifact(
     name = "deploy-linux-arm64-targz",
     target = ":assemble-linux-arm64-targz",
-    artifact_group = "vaticle_typedb_console",
+    artifact_group = "typedb-console-linux-arm64",
     artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
@@ -156,7 +156,7 @@ deploy_artifact(
 deploy_artifact(
     name = "deploy-mac-x86_64-zip",
     target = ":assemble-mac-x86_64-zip",
-    artifact_group = "vaticle_typedb_console",
+    artifact_group = "typedb-console-mac-x86_64",
     artifact_name = "typedb-console-mac-x86_64-{version}.zip",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
@@ -166,7 +166,7 @@ deploy_artifact(
 deploy_artifact(
     name = "deploy-mac-arm64-zip",
     target = ":assemble-mac-arm64-zip",
-    artifact_group = "vaticle_typedb_console",
+    artifact_group = "typedb-console-mac-arm64",
     artifact_name = "typedb-console-mac-arm64-{version}.zip",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
@@ -176,7 +176,7 @@ deploy_artifact(
 deploy_artifact(
     name = "deploy-windows-x86_64-zip",
     target = ":assemble-windows-x86_64-zip",
-    artifact_group = "vaticle_typedb_console",
+    artifact_group = "typedb-console-windows-x86_64",
     artifact_name = "typedb-console-windows-x86_64-{version}.zip",
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],

--- a/BUILD
+++ b/BUILD
@@ -138,8 +138,8 @@ deploy_artifact(
     target = ":assemble-linux-x86_64-targz",
     artifact_group = "vaticle_typedb_console",
     artifact_name = "typedb-console-linux-x86_64-{version}.tar.gz",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
 )
 
@@ -148,8 +148,8 @@ deploy_artifact(
     target = ":assemble-linux-arm64-targz",
     artifact_group = "vaticle_typedb_console",
     artifact_name = "typedb-console-linux-arm64-{version}.tar.gz",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
 )
 
@@ -158,8 +158,8 @@ deploy_artifact(
     target = ":assemble-mac-x86_64-zip",
     artifact_group = "vaticle_typedb_console",
     artifact_name = "typedb-console-mac-x86_64-{version}.zip",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
 )
 
@@ -168,8 +168,8 @@ deploy_artifact(
     target = ":assemble-mac-arm64-zip",
     artifact_group = "vaticle_typedb_console",
     artifact_name = "typedb-console-mac-arm64-{version}.zip",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
 )
 
@@ -178,8 +178,8 @@ deploy_artifact(
     target = ":assemble-windows-x86_64-zip",
     artifact_group = "vaticle_typedb_console",
     artifact_name = "typedb-console-windows-x86_64-{version}.zip",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
+    snapshot = deployment['artifact']['snapshot']['upload'],
+    release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,6 +151,12 @@ github_deps()
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
+# Load @vaticle_bazel_distribution_cloudsmith
+load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
+cloudsmith_deps()
+load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
+install_cloudsmith_deps()
+
 ################################
 # Load @vaticle dependencies #
 ################################

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,17 +119,6 @@ unuseddeps_deps()
 load("@vaticle_dependencies//tool/sonarcloud:deps.bzl", "sonarcloud_dependencies")
 sonarcloud_dependencies()
 
-# Load //tool/docs
-load("@vaticle_dependencies//tool/docs:python_deps.bzl", docs_deps = "deps")
-docs_deps()
-load("@vaticle_dependencies_tool_docs//:requirements.bzl", install_doc_deps = "install_deps")
-install_doc_deps()
-
-load("@vaticle_dependencies//tool/docs:java_deps.bzl", java_doc_deps = "deps")
-java_doc_deps()
-load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
-google_common_workspace_rules()
-
 ######################################
 # Load @vaticle_bazel_distribution #
 ######################################
@@ -151,11 +140,17 @@ github_deps()
 load("@vaticle_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
 
-# Load @vaticle_bazel_distribution_cloudsmith
-load("@vaticle_bazel_distribution//common/cloudsmith:deps.bzl", cloudsmith_deps = "deps")
-cloudsmith_deps()
-load("@vaticle_bazel_distribution_cloudsmith//:requirements.bzl", install_cloudsmith_deps = "install_deps")
-install_cloudsmith_deps()
+# Load @vaticle_bazel_distribution_uploader
+load("@vaticle_bazel_distribution//common/uploader:deps.bzl", uploader_deps = "deps")
+uploader_deps()
+load("@vaticle_bazel_distribution_uploader//:requirements.bzl", install_uploader_deps = "install_deps")
+install_uploader_deps()
+
+# Load //docs
+load("@vaticle_bazel_distribution//docs:java/deps.bzl", java_doc_deps = "deps")
+java_doc_deps()
+load("@google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
+google_common_workspace_rules()
 
 ################################
 # Load @vaticle dependencies #

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -26,7 +26,7 @@
 @maven//:com_googlecode_java_diff_utils_diffutils_1_3_0
 @maven//:com_squareup_okhttp_okhttp_2_7_5
 @maven//:com_squareup_okio_okio_1_17_5
-@maven//:com_vaticle_typedb_typedb_runner_ebc529c21f18462502b785850d7b9a4cdfe3b384
+@maven//:com_vaticle_typedb_typedb_runner_525f9e989ac9fb2d06a05e0ad61c711610803526
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io_2_3
 @maven//:commons_logging_commons_logging_1_2

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -16,6 +16,5 @@
 #
 
 maven_artifacts = {
-    'com.vaticle.typedb:typedb-runner': 'ebc529c21f18462502b785850d7b9a4cdfe3b384',
+    'com.vaticle.typedb:typedb-runner': '525f9e989ac9fb2d06a05e0ad61c711610803526',
 }
-

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "da4f5ba66210f830ab1847cf88296bec31c48455", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "3525373f84858c5fc009ba70437adc1b5e4e4486", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
 
     )
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,7 +21,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "89cbbc4e9807b10835591559bd77bd6a9a754a8a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "da4f5ba66210f830ab1847cf88296bec31c48455", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
 
     )
 
@@ -29,12 +29,12 @@ def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
         remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        commit = "9574419264352ce3eae620aaae87ed99d1706fe2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/krishnangovindraj/typedb-client-java", # typedb-driver",
-        commit = "c66084ff31d06beb17bd9501f404bf3b1be0429b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        commit = "863dd549e326962b65809c2adf5ace0b82349843",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,21 +20,20 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/krishnangovindraj/dependencies",
-        commit = "3525373f84858c5fc009ba70437adc1b5e4e4486", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
-
+        remote = "https://github.com/vaticle/dependencies",
+        commit = "a4a3bac9515fd51365e02f6aad762f67357e49a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/krishnangovindraj/typedb-common",
-        commit = "9574419264352ce3eae620aaae87ed99d1706fe2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/vaticle/typedb-common",
+        commit = "dbc333528ecdafa5b571344237e831619c3fa5f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/krishnangovindraj/typedb-client-java", # typedb-driver",
-        commit = "863dd549e326962b65809c2adf5ace0b82349843",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        remote = "https://github.com/vaticle/typedb-client-java",
+        commit = "f04d10c9cd6889c390453769f2a9664c6869298a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -20,20 +20,21 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
-        remote = "https://github.com/vaticle/dependencies",
-        commit = "41bb5bfb1b5f2adab4a88886d2e74f10d456e7e1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        remote = "https://github.com/krishnangovindraj/dependencies",
+        commit = "89cbbc4e9807b10835591559bd77bd6a9a754a8a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+
     )
 
 def vaticle_typedb_common():
     git_repository(
         name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "1f0f1ec07c9869423b5698271fcca76fde4b4f9e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
+        remote = "https://github.com/krishnangovindraj/typedb-common",
+        commit = "fd9ec61f9cc8bd0ae7a70097257d3191731316e9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
     )
 
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-driver",
-        commit = "76654b97d209ac6add07fd7342499ffadc293987",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        remote = "https://github.com/krishnangovindraj/typedb-client-java", # typedb-driver",
+        commit = "c66084ff31d06beb17bd9501f404bf3b1be0429b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -34,6 +34,6 @@ def vaticle_typedb_common():
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
-        remote = "https://github.com/vaticle/typedb-client-java",
+        remote = "https://github.com/vaticle/typedb-driver",
         commit = "f04d10c9cd6889c390453769f2a9664c6869298a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/tool/runner/BUILD
+++ b/tool/runner/BUILD
@@ -47,8 +47,8 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    snapshot = deployment['maven.snapshot'],
-    release = deployment['maven.release']
+    snapshot = deployment['maven']['snapshot']['upload'],
+    release = deployment['maven']['release']['upload'],
 )
 
 checkstyle_test(


### PR DESCRIPTION
## Usage and product changes
Updates artifact credentials, and deployment & consumption rules to use cloudsmith (repo.typedb.com) instead of the self-hosted sonatype repository (repo.vaticle.com).

## Implementation
* Updates deployment & artifact consumption rules to point to Cloudsmith and update deployment rules and repositories
* Updates artifact_groups to reflect the revised repository layout
* Update package import paths for TypeDBRunner