### PR TITLE
Remove typedb-console-runner's dependency on typedb-common

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -56,11 +56,11 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //test/assembly:test-assembly-native --test_output=streamed
     deploy-runner-maven-snapshot:
-      filter:
-        owner: vaticle
-        branch: master
+#      filter:
+#        owner: vaticle
+#        branch: master
       image: vaticle-ubuntu-22.04
-      dependencies: [build]
+#      dependencies: [build]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -56,11 +56,11 @@ build:
         bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //test/assembly:test-assembly-native --test_output=streamed
     deploy-runner-maven-snapshot:
-#      filter:
-#        owner: vaticle
-#        branch: master
+      filter:
+        owner: vaticle
+        branch: master
       image: vaticle-ubuntu-22.04
-#      dependencies: [build]
+      dependencies: [build]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_VATICLE_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_VATICLE_PASSWORD

--- a/tool/runner/BUILD
+++ b/tool/runner/BUILD
@@ -25,7 +25,6 @@ java_library(
     name = "typedb-console-runner",
     srcs = glob(["*.java"]),
     deps = [
-        "@vaticle_typedb_common//:common",
         "@maven//:info_picocli_picocli",
         "@maven//:org_zeroturnaround_zt_exec",
         "@maven//:org_slf4j_slf4j_api",

--- a/tool/runner/TypeDBConsoleRunner.java
+++ b/tool/runner/TypeDBConsoleRunner.java
@@ -23,11 +23,11 @@ import org.zeroturnaround.exec.StartedProcess;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import static com.vaticle.typedb.common.collection.Collections.concatToList;
-import static com.vaticle.typedb.common.collection.Collections.list;
 import static com.vaticle.typedb.console.tool.runner.Util.getConsoleArchiveFile;
 import static com.vaticle.typedb.console.tool.runner.Util.unarchive;
 
@@ -60,7 +60,9 @@ public class TypeDBConsoleRunner {
     }
 
     private List<String> command(String... options) {
-        List<String> cmd = concatToList(list("console"), list(options));
+        List<String> cmd = new ArrayList<>();
+        cmd.add("console");
+        cmd.addAll(Arrays.asList(options));
         return Util.typeDBCommand(cmd);
     }
 


### PR DESCRIPTION
## Usage and product changes

We remove `typedb-console-runner`'s dependency on common in order to reduce deployment complexity and make the maven library self-contained.
