### PR TITLE
Make console runner use the same java installation as the calling process

### DIFF
--- a/tool/runner/TypeDBConsoleRunner.java
+++ b/tool/runner/TypeDBConsoleRunner.java
@@ -43,6 +43,7 @@ public class TypeDBConsoleRunner {
         System.out.println(name() + " distribution archive extracted.");
         executor = new ProcessExecutor()
                 .directory(distribution.toFile())
+                .environment("JAVA_HOME", System.getProperty("java.home"))
                 .redirectOutput(System.out)
                 .redirectError(System.err)
                 .readOutput(true)


### PR DESCRIPTION
## Usage and product changes
Makes TypeDB console runner use the  same java installation as the calling process, so the system remain hermetic. 

## Implementation
* Sets `JAVA_HOME` for the console subprocess to the `java.home` system property of the host process.