### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,17 @@ jobs:
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Console $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
               -c ${CIRCLE_SHA1} -delete  $(cat VERSION) ~/dist/
 
+  sync-dependencies:
+    executor: linux-x86_64
+    steps:
+      - checkout
+      - install-bazel-linux:
+          arch: amd64
+      - run:
+          command: |
+              export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+              bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
+
   release-cleanup:
     executor: linux-x86_64-ubuntu-2204
     steps:
@@ -299,9 +310,15 @@ workflows:
             - deploy-artifact-release-mac-x86_64
             - deploy-artifact-release-mac-arm64
             - deploy-artifact-release-windows-x86_64
-      - release-cleanup:
+      - sync-dependencies:
           filters:
             branches:
               only: [release]
           requires:
             - deploy-github
+      - release-cleanup:
+          filters:
+            branches:
+              only: [release]
+          requires:
+            - sync-dependencies

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -26,7 +26,7 @@ build:
   quality:
     filter:
       owner: vaticle
-      branch: master
+      branch: [master, development]
     dependency-analysis:
       image: vaticle-ubuntu-22.04
       command: |
@@ -65,6 +65,15 @@ build:
         export DEPLOY_MAVEN_USERNAME=$REPO_TYPEDB_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_TYPEDB_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //tool/runner:deploy-maven -- snapshot
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [test-assembly]
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 release:
   filter:


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.