### PR TITLE
Explicitly install python tool dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -231,5 +231,6 @@ filegroup(
         "@vaticle_dependencies//tool/sonarcloud:code-analysis",
         "@vaticle_dependencies//tool/release/notes:create",
         "@vaticle_dependencies//tool/release/notes:validate",
+        "@vaticle_dependencies//tool/sync:dependencies",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,6 +106,8 @@ swig_deps()
 load("@vaticle_dependencies//tool/common:deps.bzl", "vaticle_dependencies_ci_pip",
     vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
 vaticle_dependencies_ci_pip()
+load("@vaticle_dependencies_ci_pip//:requirements.bzl", "install_deps")
+install_deps()
 
 # Load //tool/checkstyle
 load("@vaticle_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")


### PR DESCRIPTION
## Usage and product changes

Since the upgrade to rules-python v0.24 (https://github.com/vaticle/dependencies/pull/460), we are required to explicitly install python dependencies in the WORKSPACE file. The python tools happened to be unused, so these errors were not visible until the sync dependencies tool was restored.