### PR TITLE
Use typedb-common from typeql/common, only deploy to CloudSmith

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,6 @@ jobs:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-linux-x86_64-targz --compilation_mode=opt -- release
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-console-linux-x86_64.tar.gz ~/dist/typedb-console-linux-x86_64.tar.gz
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
 
   deploy-artifact-release-linux-arm64:
     executor: linux-arm64-amazonlinux-2
@@ -163,13 +157,7 @@ jobs:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- release
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-console-linux-arm64.tar.gz ~/dist/typedb-console-linux-arm64.tar.gz
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
-    
+
   deploy-artifact-release-mac-x86_64:
     executor: mac-x86_64
     steps:
@@ -179,13 +167,7 @@ jobs:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-mac-x86_64-zip --compilation_mode=opt -- release
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-console-mac-x86_64.zip ~/dist/typedb-console-mac-x86_64.zip
-      - persist_to_workspace:
-          root: ~/dist
-          paths: ["./*"]
-  
+
   deploy-artifact-release-mac-arm64:
     executor: mac-arm64
     steps:
@@ -195,13 +177,7 @@ jobs:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run --define version=$(cat VERSION) //:deploy-mac-arm64-zip --compilation_mode=opt -- release
-      - run: |
-          mkdir -p ~/dist
-          cp bazel-bin/typedb-console-mac-arm64.zip ~/dist/typedb-console-mac-arm64.zip
-      - persist_to_workspace:
-          root: ~/dist
-          paths: [ "./*" ] 
-          
+
   deploy-artifact-release-windows-x86_64:
     executor:
       name: win/default
@@ -212,15 +188,10 @@ jobs:
       - checkout
       - run: .circleci\windows\prepare.bat
       - run: .circleci\windows\deploy_release.bat
-      - persist_to_workspace:
-          root: dist
-          paths: [ "./*" ]
 
   deploy-github:
     executor: linux-x86_64-ubuntu-2204
     steps:
-      - attach_workspace:
-          at: ~/dist
       - checkout
       - install-bazel-apt:
           arch: amd64
@@ -231,18 +202,17 @@ jobs:
             tar -xf ghr_v0.12.1_linux_amd64.tar.gz
             ghr_v0.12.1_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Console $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
-              -c ${CIRCLE_SHA1} -delete  $(cat VERSION) ~/dist/
+              -c ${CIRCLE_SHA1} -delete $(cat VERSION)
 
   sync-dependencies:
-    executor: linux-x86_64
+    executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
       - install-bazel-linux:
           arch: amd64
       - run:
-          command: |
-              export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
-              bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${CIRCLE_PROJECT_REPONAME}@$(cat VERSION)
 
   release-cleanup:
     executor: linux-x86_64-ubuntu-2204
@@ -260,23 +230,23 @@ workflows:
       - deploy-artifact-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, development]
       - deploy-artifact-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master]
+              only: [master, development]
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, development]
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master]
+              only: [master, development]
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master]
+              only: [master, development]
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,9 +198,9 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
-            wget https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz
-            tar -xf ghr_v0.12.1_linux_amd64.tar.gz
-            ghr_v0.12.1_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
+            wget https://github.com/tcnksm/ghr/releases/download/v0.16.2/ghr_v0.16.2_linux_amd64.tar.gz
+            tar -xf ghr_v0.16.2_linux_amd64.tar.gz
+            ghr_v0.16.2_linux_amd64/ghr -t ${REPO_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} -n "TypeDB Console $(cat VERSION)" -b "$(cat ./RELEASE_NOTES_LATEST.md)" \
               -c ${CIRCLE_SHA1} -delete $(cat VERSION)
 

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -27,6 +27,3 @@ SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 SET /p VER=<VERSION
 bazel --output_user_root=C:/b run --verbose_failures --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
-
-MD dist
-COPY bazel-bin\typedb-console-windows-x86_64.zip dist\typedb-console-windows-x86_64.zip

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -19,7 +19,6 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [build]
-    typedb-common: [build, release]
     typedb-driver: [build, release]
 
 build:

--- a/BUILD
+++ b/BUILD
@@ -50,7 +50,7 @@ java_library(
         "@vaticle_typeql//java/common:common",
         "@vaticle_typeql//java/query",
         "@vaticle_typeql//java/pattern",
-        "@vaticle_typedb_common//:common",
+        "@vaticle_typeql//common/java:common",
 
         # External dependencies
         "@maven//:com_google_code_findbugs_jsr305",
@@ -187,7 +187,6 @@ release_validate_deps(
     name = "release-validate-deps",
     refs = "@vaticle_typedb_console_workspace_refs//:refs.json",
     tagged_deps = [
-        "@vaticle_typedb_common",
         "@vaticle_typedb_driver",
         "@vaticle_typeql",
     ],

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,1 +1,5 @@
+## Distribution
+
+Download from Cloudsmith: https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name:^typedb-console+version:{version}
+
 { release notes }

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,8 +159,7 @@ google_common_workspace_rules()
 ################################
 
 # Load repositories
-load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_common", "vaticle_typedb_driver")
-vaticle_typedb_common()
+load("//dependencies/vaticle:repositories.bzl", "vaticle_typedb_driver")
 vaticle_typedb_driver()
 
 load("@vaticle_typedb_driver//dependencies/vaticle:repositories.bzl", "vaticle_typedb_protocol", "vaticle_typeql")
@@ -172,7 +171,6 @@ load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", "vaticle_type
 vaticle_typedb_artifact()
 
 # Load maven
-load("@vaticle_typedb_common//dependencies/maven:artifacts.bzl", vaticle_typedb_common_artifacts = "artifacts")
 load("@vaticle_typeql//dependencies/maven:artifacts.bzl", vaticle_typeql_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/maven:artifacts.bzl", vaticle_typedb_driver_artifacts = "artifacts")
 load("@vaticle_typedb_driver//dependencies/vaticle:artifacts.bzl", vaticle_typedb_vaticle_maven_artifacts = "maven_artifacts")
@@ -184,7 +182,6 @@ load("//dependencies/maven:artifacts.bzl", vaticle_typedb_console_artifacts = "a
 
 load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
 maven(
-    vaticle_typedb_common_artifacts +
     vaticle_typeql_artifacts +
     vaticle_typedb_driver_artifacts +
     vaticle_typedb_console_artifacts +

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -35,5 +35,5 @@ def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "acc7e919746b7ed4214c9abbeede9abfb12662ab",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        commit = "20b9f1d6fbd9f2b85f1c3a33308146956f9ee4ab",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -24,16 +24,9 @@ def vaticle_dependencies():
         commit = "3bd3fbcda4567dcea41f941eb6073b8673ba2a17", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
-def vaticle_typedb_common():
-    git_repository(
-        name = "vaticle_typedb_common",
-        remote = "https://github.com/vaticle/typedb-common",
-        commit = "dbc333528ecdafa5b571344237e831619c3fa5f0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_common
-    )
-
 def vaticle_typedb_driver():
     git_repository(
         name = "vaticle_typedb_driver",
         remote = "https://github.com/vaticle/typedb-driver",
-        commit = "20b9f1d6fbd9f2b85f1c3a33308146956f9ee4ab",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
+        tag = "2.26.6-rc1",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_driver
     )


### PR DESCRIPTION
## Usage and product changes

We update Bazel dependencies and target paths following the merging of typedb-common into [vaticle/typeql](https://github.com/vaticle/typeql/) (see https://github.com/vaticle/typeql/pull/313).

We also no longer upload build artifacts to the github releases page. Instead, the artifacts are available from our public cloudsmith repository, linked in the release notes.

## Implementation

- update ghr to 0.16.2, as 0.12.1 does not support github releases without artifacts