### PR TITLE
Fix sync-dependencies job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     executor: linux-x86_64-ubuntu-2204
     steps:
       - checkout
-      - install-bazel-linux:
+      - install-bazel-apt:
           arch: amd64
       - run:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN


### PR DESCRIPTION
## Usage and product changes

The sync-dependencies step in CircleCI used an obsolete setup step which no longer exists. This PR fixes that issue.