### PR TITLE
Fix git patch for Windows build

### DIFF
--- a/.circleci/windows/short_workspace.patch
+++ b/.circleci/windows/short_workspace.patch
@@ -1,9 +1,13 @@
 diff --git a/WORKSPACE b/WORKSPACE
-index 689b420f..5e3ecec8 100644
+index 4a7855a..d2c3b4a 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -4,3 +4,3 @@
-
+@@ -2,7 +2,7 @@
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ 
 -workspace(name = "vaticle_typedb_console")
 +workspace(name = "v")
-
+ 
+ ################################
+ # Load @vaticle_dependencies #


### PR DESCRIPTION
## Usage and product changes

We update the git patch used for workspace path shortening in Windows CI builds.