### PR TITLE
Turn off statistics reporting in CI

### DIFF
--- a/test/assembly/AssemblyTest.java
+++ b/test/assembly/AssemblyTest.java
@@ -24,6 +24,7 @@ public class AssemblyTest {
         TypeDBConsoleRunner consoleRunner = new TypeDBConsoleRunner();
         Map<String, String> coreOptions = new HashMap<>();
         coreOptions.put("--diagnostics.reporting.errors", "false");
+        coreOptions.put("--diagnostics.reporting.statistics", "false");
         coreOptions.put("--diagnostics.monitoring.enable", "false");
         TypeDBCoreRunner coreRunner = new TypeDBCoreRunner(coreOptions);
         try {


### PR DESCRIPTION
## Usage and product changes
We turn off the `--diagnostics.reporting.statistics` in our CI builds not to send non-real diagnostics data.

In version 2.28 and earlier, this flag purely prevents `TypeDB` from sending any diagnostics data.
In the upcoming version 2.28.1, this flag still allows `TypeDB` to send a single diagnostics snapshot with the information of when the diagnostics data has been turned off, but it happens only after the server runs for 1 hour, so we expect the CI builds not to reach this point and not to send any diagnostics data as well.
