### PR TITLE
Bump dependencies for rules-python & pin CircleCI windows executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,11 @@ executors:
       xcode: "13.4.1"
     working_directory: ~/typedb-console
 
+  win-x86_64:
+    resource_class: windows.xlarge
+    machine:
+      image: windows-server-2022-gui:2024.01.1
+    shell: cmd.exe
 
 commands:
   install-bazel-yum:
@@ -113,10 +118,7 @@ jobs:
           bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-arm64-zip -- snapshot
 
   deploy-artifact-snapshot-windows-x86_64:
-    executor:
-      name: win/default
-      shell: cmd.exe
-      size: large
+    executor: win-x86_64
     working_directory: ~/typedb-driver
     steps:
       - checkout
@@ -166,10 +168,7 @@ jobs:
           bazel run --define version=$(cat VERSION) //:deploy-mac-arm64-zip --compilation_mode=opt -- release
 
   deploy-artifact-release-windows-x86_64:
-    executor:
-      name: win/default
-      shell: cmd.exe
-      size: large
+    executor: win-x86_64
     working_directory: ~/typedb-driver
     steps:
       - checkout

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -125,5 +125,5 @@
 @maven//:org_slf4j_log4j_over_slf4j_2_0_0
 @maven//:org_slf4j_slf4j_api_2_0_0
 @maven//:org_slf4j_slf4j_simple_2_0_0
-@maven//:org_yaml_snakeyaml_1_25
+@maven//:org_yaml_snakeyaml_2_2
 @maven//:org_zeroturnaround_zt_exec_1_10

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -8,7 +8,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "0a54a3551ef149346832d65a9c844429fff76f12", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "729d960a92e145e03794395bbe59e02f122f1aee", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_driver():


### PR DESCRIPTION
## Usage and product changes
Bump dependencies for rules-python update. This fixes an error on windows builds in CircleCI.
We also pin the image used for Windows builds  on CircleCI to prevent updates from breaking the pipeline.