### PR TITLE
Migrate CircleCI mac jobs to arm64 executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2.1
 
 orbs:
   win: circleci/windows@5.0.0
+  macos: circleci/macos@2.4.0
 
 executors:
   linux-arm64-amazonlinux-2:
@@ -30,11 +31,6 @@ executors:
     macos:
       xcode: "13.4.1"
     resource_class: macos.m1.medium.gen1
-    working_directory: ~/typedb-console
-
-  mac-x86_64:
-    macos:
-      xcode: "13.4.1"
     working_directory: ~/typedb-console
 
   win-x86_64:
@@ -74,6 +70,10 @@ commands:
     steps:
       - run: brew install bazelisk
 
+  install-brew-rosetta:
+    steps:
+      - run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
 jobs:
   deploy-artifact-snapshot-linux-x86_64:
     executor: linux-x86_64-amazonlinux-2
@@ -98,9 +98,11 @@ jobs:
           bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-arm64-targz -- snapshot
 
   deploy-artifact-snapshot-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
       - checkout
+      - macos/install-rosetta
+      - install-brew-rosetta
       - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
@@ -148,9 +150,11 @@ jobs:
           bazel run --define version=$(cat VERSION) //:deploy-linux-arm64-targz --compilation_mode=opt -- release
 
   deploy-artifact-release-mac-x86_64:
-    executor: mac-x86_64
+    executor: mac-arm64
     steps:
       - checkout
+      - macos/install-rosetta
+      - install-brew-rosetta
       - install-bazel-brew
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
@@ -224,7 +228,7 @@ workflows:
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development]
+              only: [master, development, migrate-mac-executor]
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ workflows:
       - deploy-artifact-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, development, migrate-mac-executor]
+              only: [master, development]
       - deploy-artifact-snapshot-mac-arm64:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,16 @@ commands:
           mv "bazelisk-linux-<<parameters.arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
 
-  install-bazel-brew:
+  install-bazel-mac:
+    parameters:
+      bazel-arch:
+        type: string
     steps:
-      - run: brew install bazelisk
-
-  install-brew-rosetta:
-    steps:
-      - run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - run: |
+          brew install python@3.8
+          curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
+          sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
+          chmod a+x /usr/local/bin/bazel
 
 jobs:
   deploy-artifact-snapshot-linux-x86_64:
@@ -102,8 +105,8 @@ jobs:
     steps:
       - checkout
       - macos/install-rosetta
-      - install-brew-rosetta
-      - install-bazel-brew
+      - install-bazel-mac:
+          bazel-arch: amd64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
@@ -113,7 +116,8 @@ jobs:
     executor: mac-arm64
     steps:
       - checkout
-      - install-bazel-brew
+      - install-bazel-mac:
+          bazel-arch: arm64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
@@ -154,8 +158,8 @@ jobs:
     steps:
       - checkout
       - macos/install-rosetta
-      - install-brew-rosetta
-      - install-bazel-brew
+      - install-bazel-mac:
+          bazel-arch: amd64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
@@ -165,7 +169,8 @@ jobs:
     executor: mac-arm64
     steps:
       - checkout
-      - install-bazel-brew
+      - install-bazel-mac:
+          bazel-arch: arm64
       - run: |
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD


### PR DESCRIPTION
## Usage and product changes
Migrates the  CircleCI mac jobs to arm64 executors

## Implementation
Migrates the  CircleCI mac jobs to arm64 executors, ahead of the shut-down of x86_64 executors on June 28th. In jobs for x86_64 builds of Mac, we update the steps to:
* Install rosetta
* Install bazelisk for the specific architecture, passed via a parameter ``<<bazel.arch>>`
