### PR TITLE
 Fix windows deployment jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ workflows:
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development, "3.0", "bazel-8-windows-snapshot-tests"]
+              only: [master, development, "3.0"]
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ workflows:
       - deploy-artifact-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [master, development, "3.0"]
+              only: [master, development, "3.0", "bazel-8-windows-snapshot-tests"]
 
   release:
     jobs:

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -15,5 +15,5 @@ REM Bazel binary must produce a `.exe` instead of a binary without a file extens
 git apply .circleci\windows\package_binary_as_exe.patch
 
 SET /p VER=<VERSION
-bazel --output_user_root=C:/b run --verbose_failures --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- release
+bazel --output_user_root=C:/b run --verbose_failures --enable_runfiles --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -16,5 +16,5 @@ git apply .circleci\windows\package_binary_as_exe.patch
 
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --output_user_root=C:/b run --verbose_failures --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- snapshot
+bazel --output_user_root=C:/b run --verbose_failures --enable_runfiles --define version=%VER% //:deploy-windows-x86_64-zip --compilation_mode=opt -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/short_workspace.patch
+++ b/.circleci/windows/short_workspace.patch
@@ -1,13 +1,13 @@
-diff --git a/WORKSPACE b/WORKSPACE
-index 4a7855a..d2c3b4a 100644
---- a/WORKSPACE
-+++ b/WORKSPACE
-@@ -2,7 +2,7 @@
- # License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --git a/MODULE.bazel b/MODULE.bazel
+index bd05d48..cac168f 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -3,7 +3,7 @@
  # file, You can obtain one at https://mozilla.org/MPL/2.0/.
  
--workspace(name = "typedb_console")
-+workspace(name = "v")
- 
- ################################
- # Load @typedb_dependencies #
+ module(
+-    name = "typedb_console",
++    name = "v",
+     version = "0.0.0",
+     compatibility_level = 1,
+ )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,4 +3,3 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Intentionally empty - dependencies managed via MODULE.bazel
-workspace(name = "typedb_console")


### PR DESCRIPTION
## Usage and product changes
Usage and product changes Fix windows deployment jobs by adding --enable-runfiles. Also updates the patch.