### PR TITLE
Restore dependencies folder because it's hardcoded

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -145,7 +145,6 @@ release_validate_deps(
     name = "release-validate-deps",
     refs = "@typedb_console_workspace_refs//:refs.json",
     tagged_deps = [
-        "@typedb_protocol+",
         "@typedb_driver+",
         "@typeql+",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,12 +106,10 @@ workspace_refs(
     workspace_commit_dict = {
         "typeql+": "1ef9ff633cbe564ce661de0686aa7ba7b0fac0ad",
         "typedb_driver+": "b657d41034f1039490403ca6f950e20d1c064eda",
-        "typedb_protocol+": "d932b39be41bf5455108f225295208029a236543",
     },
     workspace_tag_dict = {
         "typeql+": "3.8.3-rc0",
         "typedb_driver+": "3.8.2-rc0",
-        "typedb_protocol+": "3.7.1-rc1",
     },
 )
 

--- a/dependencies/typedb/BUILD
+++ b/dependencies/typedb/BUILD
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "mpl-header",
+)
+

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def typedb_dependencies():
+    git_repository(
+        name = "typedb_dependencies",
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "5243b487cec48bd5b18ef744964f42b249bee7f8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+    )
+
+def typedb_driver():
+    git_repository(
+        name = "typedb_driver",
+        remote = "https://github.com/typedb/typedb-driver",
+        tag = "3.8.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+    )
+
+def typeql():
+    git_repository(
+        name = "typeql",
+        remote = "https://github.com/typedb/typeql",
+        tag = "3.8.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+    )


### PR DESCRIPTION
## Usage and product changes
Restore dependencies folder because it's hardcoded