### PR TITLE
Fetch TypeDB server using native_artifact_files module extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,8 +24,8 @@ bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf"
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
-    remote = "https://github.com/krishnangovindraj/dependencies",
-    commit = "89fb404efbb4735dbec9f3edc33ba9d7b62c1ad2",
+    remote = "https://github.com/typedb/dependencies",
+    commit = "5b0fa39ccdac93ad486c83cffbbafdbc0bfd83f6",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,8 +24,8 @@ bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf"
 bazel_dep(name = "typedb_dependencies", version = "0.0.0")
 git_override(
     module_name = "typedb_dependencies",
-    remote = "https://github.com/typedb/dependencies",
-    commit = "a798dc0869d494bf0c7b033ee226df2efbef2830",
+    remote = "https://github.com/krishnangovindraj/dependencies",
+    commit = "89fb404efbb4735dbec9f3edc33ba9d7b62c1ad2",
 )
 
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
@@ -113,36 +113,20 @@ workspace_refs(
     },
 )
 
-# TypeDB server artifacts for integration tests
-# These download the TypeDB server binary for assembly tests
-http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-
-http_file(
-    name = "typedb_artifact_linux-arm64",
-    urls = ["https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-arm64/versions/3.8.0/typedb-all-linux-arm64-3.8.0.tar.gz"],
-    downloaded_file_path = "typedb-all-linux-arm64-3.8.0.tar.gz",
+# TypeDB server artifacts for testing
+# These download the TypeDB server binary for integration/behaviour tests
+native_artifact_files = use_extension("@typedb_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")
+native_artifact_files.artifact(
+    name = "typedb_artifact",
+    group_name = "typedb-all-{platform}",
+    artifact_name = "typedb-all-{platform}-{version}.{ext}",
+    tag = "3.8.3",
 )
-
-http_file(
-    name = "typedb_artifact_linux-x86_64",
-    urls = ["https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-x86_64/versions/3.8.0/typedb-all-linux-x86_64-3.8.0.tar.gz"],
-    downloaded_file_path = "typedb-all-linux-x86_64-3.8.0.tar.gz",
-)
-
-http_file(
-    name = "typedb_artifact_mac-arm64",
-    urls = ["https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-arm64/versions/3.8.0/typedb-all-mac-arm64-3.8.0.zip"],
-    downloaded_file_path = "typedb-all-mac-arm64-3.8.0.zip",
-)
-
-http_file(
-    name = "typedb_artifact_mac-x86_64",
-    urls = ["https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-x86_64/versions/3.8.0/typedb-all-mac-x86_64-3.8.0.zip"],
-    downloaded_file_path = "typedb-all-mac-x86_64-3.8.0.zip",
-)
-
-http_file(
-    name = "typedb_artifact_windows-x86_64",
-    urls = ["https://repo.typedb.com/public/public-release/raw/names/typedb-all-windows-x86_64/versions/3.8.0/typedb-all-windows-x86_64-3.8.0.zip"],
-    downloaded_file_path = "typedb-all-windows-x86_64-3.8.0.zip",
+use_repo(
+    native_artifact_files,
+     "typedb_artifact_linux-x86_64",
+     "typedb_artifact_linux-arm64",
+     "typedb_artifact_mac-x86_64",
+     "typedb_artifact_mac-arm64",
+     "typedb_artifact_windows-x86_64",
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -8275,6 +8275,79 @@
         ]
       }
     },
+    "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
+      "general": {
+        "bzlTransitiveDigest": "Gen/GwEHHAvak8+gnn0Ci/OUihHT9IcTIquSmKkXOmc=",
+        "usagesDigest": "vRL0EozQH/exjSBoITNrH2INnzmZkdJCzuFg0xohr+k=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "typedb_artifact_linux-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-arm64/versions/3.8.3/typedb-all-linux-arm64-3.8.3.tar.gz"
+              ],
+              "downloaded_file_path": "typedb-all-linux-arm64-3.8.3.tar.gz"
+            }
+          },
+          "typedb_artifact_linux-x86_64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-linux-x86_64/versions/3.8.3/typedb-all-linux-x86_64-3.8.3.tar.gz"
+              ],
+              "downloaded_file_path": "typedb-all-linux-x86_64-3.8.3.tar.gz"
+            }
+          },
+          "typedb_artifact_mac-arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-arm64/versions/3.8.3/typedb-all-mac-arm64-3.8.3.zip"
+              ],
+              "downloaded_file_path": "typedb-all-mac-arm64-3.8.3.zip"
+            }
+          },
+          "typedb_artifact_mac-x86_64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-mac-x86_64/versions/3.8.3/typedb-all-mac-x86_64-3.8.3.zip"
+              ],
+              "downloaded_file_path": "typedb-all-mac-x86_64-3.8.3.zip"
+            }
+          },
+          "typedb_artifact_windows-x86_64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "urls": [
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-all-windows-x86_64/versions/3.8.3/typedb-all-windows-x86_64-3.8.3.zip"
+              ],
+              "downloaded_file_path": "typedb-all-windows-x86_64-3.8.3.zip"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "typedb_bazel_distribution+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "typedb_dependencies+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "typedb_dependencies+",
+            "typedb_bazel_distribution",
+            "typedb_bazel_distribution+"
+          ]
+        ]
+      }
+    },
     "@@typedb_dependencies+//library/maven:maven_extension.bzl%maven": {
       "general": {
         "bzlTransitiveDigest": "/1GgGaqvvh9dMGzSw9vP/DjY2L59wajADIxosbWZaDs=",


### PR DESCRIPTION
## Usage and product changes
Fetches the TypeDB server artifact using native_artifacts_files, close to how we used to with bazel 6.