### PR TITLE
Enable running CI without cache credentials, run CI on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ name: Build & checkstyle
 on:
   pull_request:
   push:
-    branches: [development, master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Build everything
         run: bazel build //...
       - name: Checkstyle

--- a/.github/workflows/console-release.yml
+++ b/.github/workflows/console-release.yml
@@ -34,7 +34,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Validate dependencies
         env:
           ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
@@ -68,7 +68,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Deploy release artifact to Cloudsmith
         shell: bash
         env:

--- a/.github/workflows/loader-release.yml
+++ b/.github/workflows/loader-release.yml
@@ -34,7 +34,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Validate dependencies
         env:
           ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
@@ -68,7 +68,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Deploy release artifact to Cloudsmith
         shell: bash
         env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -34,7 +34,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Deploy snapshot
         shell: bash
         env:
@@ -98,7 +98,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Deploy snapshot
         shell: bash
         env:

--- a/.github/workflows/test-console.yml
+++ b/.github/workflows/test-console.yml
@@ -38,7 +38,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: true
           repository-cache: true
-          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON_BREAK_THIS }}
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //console/tests/assembly:test-assembly --test_output=streamed

--- a/.github/workflows/test-console.yml
+++ b/.github/workflows/test-console.yml
@@ -9,7 +9,6 @@ name: Console tests
 # integration regardless of what the patch touched.
 on:
   push:
-    branches: [development, master]
   pull_request:
     paths:
       - 'console/**'

--- a/.github/workflows/test-console.yml
+++ b/.github/workflows/test-console.yml
@@ -9,6 +9,7 @@ name: Console tests
 # integration regardless of what the patch touched.
 on:
   push:
+    branches: [development, master]
   pull_request:
     paths:
       - 'console/**'
@@ -38,7 +39,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: true
           repository-cache: true
-          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON_BREAK_THIS }}
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //console/tests/assembly:test-assembly --test_output=streamed

--- a/.github/workflows/test-console.yml
+++ b/.github/workflows/test-console.yml
@@ -41,6 +41,6 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //console/tests/assembly:test-assembly --test_output=streamed
       - run: bazel test //console/tests/assembly:test-script --test_output=streamed

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -54,7 +54,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: true
           repository-cache: true
-          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON_BREAK_THIS }}
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //loader/tests/assembly:test-loader --test_output=streamed

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -41,7 +41,7 @@ jobs:
           repository-cache: true
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //loader:loader-unit-tests --test_output=streamed
 
   assembly-tests:
@@ -54,7 +54,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: true
           repository-cache: true
-          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON_BREAK_THIS }}
           bazelrc: |
-            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+            build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - run: bazel test //loader/tests/assembly:test-loader --test_output=streamed

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -9,7 +9,6 @@ name: Loader tests
 # integration regardless of what the patch touched.
 on:
   push:
-    branches: [development, master]
   pull_request:
     paths:
       - 'loader/**'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "typedb-driver"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-driver?rev=747c22ea532e03e25e26814e7079df09910f8257#747c22ea532e03e25e26814e7079df09910f8257"
+source = "git+https://github.com/typedb/typedb-driver?rev=48157a455caeeee9342f659d07b09bdb618a5f04#48157a455caeeee9342f659d07b09bdb618a5f04"
 dependencies = [
  "async-std",
  "chrono",
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=bb9c513d4dcff269feb88015dcf99354ad378657#bb9c513d4dcff269feb88015dcf99354ad378657"
+source = "git+https://github.com/typedb/typedb-protocol?rev=3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf#3a39f0b94fd7ea316ba5a4f74d44d5afc454cedf"
 dependencies = [
  "prost",
  "tonic",
@@ -3285,13 +3285,20 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=aff2bd809b2c6e17e76d25ce3ae731bf14ed03c4#aff2bd809b2c6e17e76d25ce3ae731bf14ed03c4"
+source = "git+https://github.com/typedb/typeql?rev=405c5383a35277acc40bb0921ffd2e8eb1b1b00d#405c5383a35277acc40bb0921ffd2e8eb1b1b00d"
 dependencies = [
  "chrono",
  "itertools",
  "pest",
  "pest_derive",
  "regex",
+]
+
+[[package]]
+name = "typeql-check"
+version = "0.0.0"
+dependencies = [
+ "typeql",
 ]
 
 [[package]]


### PR DESCRIPTION
## Usage and product changes

- Allow CI to run without bazel cache credentials
- Run CI on all `push` actions
  - Our cache is read-only public, so by running on `push` actions we allow users with read/write access to write to the cache from their forks

## Implementation

- Hardcode the cache URL
- Remove branch restrictions on `push` triggers for build and test actions