### PR TITLE
Set CARGO_BAZEL_GENERATOR_URL in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
       - name: Build everything
+        env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-linux-x86_64
         run: bazel build //...
       - name: Checkstyle
         run: |

--- a/.github/workflows/console-release.yml
+++ b/.github/workflows/console-release.yml
@@ -72,10 +72,10 @@ jobs:
       - name: Deploy release artifact to Cloudsmith
         shell: bash
         env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-${{matrix.target.label}}
           DEPLOY_ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
           DEPLOY_ARTIFACT_PASSWORD: ${{ secrets.REPO_TYPEDB_PASSWORD }}
         run: |
-          export CARGO_BAZEL_GENERATOR_URL="repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-${{matrix.target.label}}"
           bazel run --define version=$(cat VERSION) \
             --compilation_mode=opt \
             ${{ matrix.target.bazel }} -- release

--- a/.github/workflows/loader-release.yml
+++ b/.github/workflows/loader-release.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Deploy release artifact to Cloudsmith
         shell: bash
         env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-${{matrix.target.label}}
           DEPLOY_ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
           DEPLOY_ARTIFACT_PASSWORD: ${{ secrets.REPO_TYPEDB_PASSWORD }}
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Deploy snapshot
         shell: bash
         env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-${{matrix.target.label}}
           DEPLOY_ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
           DEPLOY_ARTIFACT_PASSWORD: ${{ secrets.REPO_TYPEDB_PASSWORD }}
         run: |
@@ -102,6 +103,7 @@ jobs:
       - name: Deploy snapshot
         shell: bash
         env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-${{matrix.target.label}}
           DEPLOY_ARTIFACT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
           DEPLOY_ARTIFACT_PASSWORD: ${{ secrets.REPO_TYPEDB_PASSWORD }}
         run: |

--- a/.github/workflows/test-console.yml
+++ b/.github/workflows/test-console.yml
@@ -41,5 +41,11 @@ jobs:
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
-      - run: bazel test //console/tests/assembly:test-assembly --test_output=streamed
-      - run: bazel test //console/tests/assembly:test-script --test_output=streamed
+      - name: test console assembly assembly
+        env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-linux-x86_64
+        run: bazel test //console/tests/assembly:test-assembly --test_output=streamed
+      - name: test console assembly script
+        env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-linux-x86_64
+        run: bazel test //console/tests/assembly:test-script --test_output=streamed

--- a/.github/workflows/test-loader.yml
+++ b/.github/workflows/test-loader.yml
@@ -56,4 +56,7 @@ jobs:
           google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
           bazelrc: |
             build --remote_cache https://storage.googleapis.com/typedb-engineers-bazel-remote-cache-europe-west1
-      - run: bazel test //loader/tests/assembly:test-loader --test_output=streamed
+      - name: test loader assembly
+        env:
+          CARGO_BAZEL_GENERATOR_URL: https://repo.typedb.com/public/public-tools/raw/versions/0.0.0/cargo-bazel-linux-x86_64
+        run: bazel test //loader/tests/assembly:test-loader --test_output=streamed


### PR DESCRIPTION
## Usage and product changes
Set CARGO_BAZEL_GENERATOR_URL in github actions to use pre-built cargo-bazel tool. 

## Implementation
Similar to https://github.com/typedb/typedb/pull/7837