### PR TITLE
Use release tag prefix in release note validation

### DIFF
--- a/.github/workflows/console-release.yml
+++ b/.github/workflows/console-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate release notes
         env:
           NOTES_VALIDATE_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
-        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md
+        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md ${RELEASE_TAG_PREFIX}
 
   deploy-artifacts:
     name: Deploy ${{ matrix.target.label }}

--- a/.github/workflows/loader-release.yml
+++ b/.github/workflows/loader-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate release notes
         env:
           NOTES_VALIDATE_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
-        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md
+        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md ${RELEASE_TAG_PREFIX}
 
   deploy-artifacts:
     name: Deploy ${{ matrix.target.label }}

--- a/.github/workflows/typeql-check-release.yml
+++ b/.github/workflows/typeql-check-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Validate release notes
         env:
           NOTES_VALIDATE_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
-        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md
+        run: bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- ${{ github.repository_owner }} ${{ github.event.repository.name }} ./RELEASE_NOTES_LATEST.md ${RELEASE_TAG_PREFIX}
 
   deploy-artifacts:
     name: Deploy ${{ matrix.target.label }}


### PR DESCRIPTION
## Usage and product changes

Use the release tag prefix when validation release notes

## Implementation

Pass the `RELEASE_TAG_PREFIX` environment variable to the release note validator