### PR TITLE
Add brew and apt deployment to release workflow for TypeQL Check

### DIFF
--- a/.github/workflows/typeql-check-release.yml
+++ b/.github/workflows/typeql-check-release.yml
@@ -94,6 +94,38 @@ jobs:
           name: checksum-${{ matrix.target.label }}
           path: checksum-${{ matrix.target.label }}
 
+  # Publishes the .deb packages to the shared Cloudsmith apt repo. Each architecture is built
+  # natively on its matching runner.
+  deploy-apt:
+    name: Deploy apt ${{ matrix.target.label }}
+    runs-on: ${{ matrix.target.runner }}
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { label: linux-x86_64, runner: ubuntu-22.04, bazel: "//typeql-check:deploy-apt-x86_64" }
+          - { label: linux-arm64, runner: ubuntu-22.04-arm, bazel: "//typeql-check:deploy-apt-arm64" }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+      - name: Deploy apt package to Cloudsmith
+        shell: bash
+        env:
+          DEPLOY_APT_USERNAME: ${{ vars.REPO_TYPEDB_USERNAME }}
+          DEPLOY_APT_PASSWORD: ${{ secrets.REPO_TYPEDB_PASSWORD }}
+        run: |
+          bazel run --define version=$(cat VERSION) \
+            --compilation_mode=opt \
+            ${{ matrix.target.bazel }} -- release
+
   # Publishes the typeql-check formula to the shared typedb/homebrew-tap. Needs the mac zip
   # checksums produced by deploy-artifacts.
   deploy-brew:

--- a/.github/workflows/typeql-check-release.yml
+++ b/.github/workflows/typeql-check-release.yml
@@ -79,6 +79,57 @@ jobs:
           bazel run --define version=$(cat VERSION) \
             --compilation_mode=opt \
             ${{ matrix.target.bazel }} -- release
+      # The brew formula pins the sha256 of each mac zip. The deploy step above already built the
+      # assemble target, so checksum the resulting zip and hand it off to the deploy-brew job.
+      - name: Checksum mac artifact for brew
+        if: startsWith(matrix.target.label, 'mac')
+        shell: bash
+        run: |
+          shasum -a 256 bazel-bin/typeql-check/typeql-check-${{ matrix.target.label }}.zip \
+            | awk '{print $1}' > "checksum-${{ matrix.target.label }}"
+      - name: Upload mac checksum
+        if: startsWith(matrix.target.label, 'mac')
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-${{ matrix.target.label }}
+          path: checksum-${{ matrix.target.label }}
+
+  # Publishes the typeql-check formula to the shared typedb/homebrew-tap. Needs the mac zip
+  # checksums produced by deploy-artifacts.
+  deploy-brew:
+    name: Deploy brew
+    runs-on: ubuntu-22.04
+    needs: deploy-artifacts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
+      - name: Download mac checksums
+        uses: actions/download-artifact@v4
+        with:
+          pattern: checksum-mac-*
+          path: checksums
+          merge-multiple: true
+      - name: Deploy brew formula
+        shell: bash
+        env:
+          DEPLOY_BREW_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+          DEPLOY_BREW_USERNAME: ${{ secrets.REPO_GITHUB_USERNAME }}
+          DEPLOY_BREW_EMAIL: ${{ secrets.REPO_GITHUB_EMAIL }}
+        run: |
+          # deploy_brew reads the sha256 from these files via the checksum-mac-* label flags.
+          cp checksums/checksum-mac-arm64 typeql-check/checksum-arm64
+          cp checksums/checksum-mac-x86_64 typeql-check/checksum-x86_64
+          bazel run --define version=$(cat VERSION) //typeql-check:deploy-brew \
+            --//typeql-check:checksum-mac-arm64=//typeql-check:checksum-arm64 \
+            --//typeql-check:checksum-mac-x86_64=//typeql-check:checksum-x86_64 \
+            --compilation_mode=opt -- release
 
   # Windows uses the custom batch-script process (see .github/windows): it shortens the Bazel
   # workspace path, installs build dependencies via Chocolatey, and patches the binary to a `.exe`

--- a/typeql-check/BUILD
+++ b/typeql-check/BUILD
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:__subpackages__"])
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@typedb_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
+load("@typedb_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@typedb_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip")
 load("@typedb_dependencies//distribution:deployment.bzl", "deployment")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
@@ -121,6 +122,36 @@ deploy_artifact(
     snapshot = deployment['artifact']['snapshot']['upload'],
     release = deployment['artifact']['release']['upload'],
     visibility = ["//visibility:public"],
+)
+
+# brew
+deploy_brew(
+    name = "deploy-brew",
+    file_substitutions = {
+        ":checksum-mac-arm64": "{sha256-arm64}",
+        ":checksum-mac-x86_64": "{sha256-x86_64}",
+    },
+    formula = "//typeql-check/brew:typeql-check.rb",
+    release = deployment["brew"]["release"],
+    snapshot = deployment["brew"]["snapshot"],
+    version_file = "//:VERSION",
+)
+
+genrule(
+    name = "invalid-checksum",
+    outs = ["invalid-checksum.txt"],
+    srcs = [],
+    cmd = "echo > $@",
+)
+
+label_flag(
+    name = "checksum-mac-arm64",
+    build_setting_default = ":invalid-checksum",
+)
+
+label_flag(
+    name = "checksum-mac-x86_64",
+    build_setting_default = ":invalid-checksum",
 )
 
 checkstyle_test(

--- a/typeql-check/BUILD
+++ b/typeql-check/BUILD
@@ -5,6 +5,7 @@
 package(default_visibility = ["//visibility:__subpackages__"])
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@typedb_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@typedb_bazel_distribution//artifact:rules.bzl", "deploy_artifact")
 load("@typedb_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@typedb_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_zip")
@@ -135,6 +136,50 @@ deploy_brew(
     release = deployment["brew"]["release"],
     snapshot = deployment["brew"]["snapshot"],
     version_file = "//:VERSION",
+)
+
+# apt
+# Each .deb is built natively on its matching runner (amd64 / arm64), reusing the same
+# native artifact tar as the targz/zip distributions. The binary lands under /opt/typedb and
+# is symlinked onto PATH at /usr/local/bin/typeql-check.
+assemble_apt(
+    name = "assemble-linux-x86_64-apt",
+    package_name = "typeql-check",
+    architecture = "amd64",
+    archives = [":typeql-check-artifact-native"],
+    description = "Validate TypeQL query syntax from the command line",
+    installation_dir = "/opt/typedb/typeql-check/",
+    maintainer = "TypeDB Community <community@typedb.com>",
+    symlinks = {
+        "/usr/local/bin/typeql-check": "/opt/typedb/typeql-check/typeql-check",
+    },
+)
+
+assemble_apt(
+    name = "assemble-linux-arm64-apt",
+    package_name = "typeql-check",
+    architecture = "arm64",
+    archives = [":typeql-check-artifact-native"],
+    description = "Validate TypeQL query syntax from the command line",
+    installation_dir = "/opt/typedb/typeql-check/",
+    maintainer = "TypeDB Community <community@typedb.com>",
+    symlinks = {
+        "/usr/local/bin/typeql-check": "/opt/typedb/typeql-check/typeql-check",
+    },
+)
+
+deploy_apt(
+    name = "deploy-apt-x86_64",
+    target = ":assemble-linux-x86_64-apt",
+    release = deployment["apt"]["release"]["upload"],
+    snapshot = deployment["apt"]["snapshot"]["upload"],
+)
+
+deploy_apt(
+    name = "deploy-apt-arm64",
+    target = ":assemble-linux-arm64-apt",
+    release = deployment["apt"]["release"]["upload"],
+    snapshot = deployment["apt"]["snapshot"]["upload"],
 )
 
 genrule(

--- a/typeql-check/brew/BUILD
+++ b/typeql-check/brew/BUILD
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+exports_files(["typeql-check.rb"])
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "mpl-header",
+)

--- a/typeql-check/brew/typeql-check.rb
+++ b/typeql-check/brew/typeql-check.rb
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+class TypeqlCheck < Formula
+  desc "Validate TypeQL query syntax from the command line"
+  homepage "https://typedb.com"
+
+  on_arm do
+    url "https://repo.typedb.com/public/public-release/raw/names/typeql-check-mac-arm64/versions/{version}/typeql-check-mac-arm64-{version}.zip"
+    sha256 "{sha256-arm64}"
+  end
+
+  on_intel do
+    url "https://repo.typedb.com/public/public-release/raw/names/typeql-check-mac-x86_64/versions/{version}/typeql-check-mac-x86_64-{version}.zip"
+    sha256 "{sha256-x86_64}"
+  end
+
+  license "MPL-2.0"
+
+  def install
+    bin.install "typeql-check"
+  end
+end


### PR DESCRIPTION
## Usage and product changes

Adds two new distribution channels for the `typeql-check` CLI, so it can be installed via `brew install typedb/tap/typeql-check` and `apt-get install typeql-check` alongside the existing tar.gz/zip artifacts.


## Implementation

### Homebrew
- New `deploy-brew` job publishes the `typeql-check` formula to the shared `typedb/homebrew-tap` on release (mirrors TypeDB's CircleCI `deploy-brew`, ported to GitHub Actions).
- The mac build jobs checksum their zips and export the sha256 as workflow artifacts; `deploy-brew` consumes them via the `checksum-mac-*` label flags and templates them into the formula.
- Formula pins per-arch URLs/sha256 for `on_arm`/`on_intel`.

### apt
- New `deploy-apt` CI matrix builds per-arch `.deb` packages (amd64/arm64) natively on each runner, reusing the same native artifact tar as the targz/zip distributions.
- Binary installs to `/opt/typedb/typeql-check/` and is symlinked onto `PATH` at `/usr/local/bin/typeql-check`.
- Publishes to the shared Cloudsmith apt repo via `deploy_apt`.
