### PR TITLE
Setup bazel on windows using setup-bazel action

### DIFF
--- a/.github/windows/dependencies.config
+++ b/.github/windows/dependencies.config
@@ -5,7 +5,6 @@
   -->
 
 <packages>
-    <package id="bazelisk" version="1.17.0"/>
     <package id="python" version="3.11.0"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/.github/workflows/console-release.yml
+++ b/.github/workflows/console-release.yml
@@ -100,6 +100,14 @@ jobs:
     needs: validate
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat

--- a/.github/workflows/loader-release.yml
+++ b/.github/workflows/loader-release.yml
@@ -100,6 +100,14 @@ jobs:
     needs: validate
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -60,6 +60,14 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat
@@ -79,6 +87,14 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat
@@ -138,6 +154,14 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat

--- a/.github/workflows/typeql-check-release.yml
+++ b/.github/workflows/typeql-check-release.yml
@@ -184,6 +184,14 @@ jobs:
     needs: validate
     steps:
       - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: true
+          repository-cache: true
+          google-credentials: ${{ secrets.BAZEL_CACHE_CREDENTIAL_JSON }}
+          bazelrc: |
+            build --remote_cache ${{ vars.BAZEL_CACHE_URL }}
       - name: Prepare Windows build environment
         shell: cmd
         run: .github\windows\prepare.bat


### PR DESCRIPTION
## Usage and product changes
Replaces the choco based bazel setup with the `setup-bazel` action. This makes the setup similar to mac and should enable the bazel remote-cache
