### PR TITLE
Improve loader CLI ergonomics

### DIFF
--- a/loader/checkpoint.rs
+++ b/loader/checkpoint.rs
@@ -198,7 +198,7 @@ impl CheckpointWriter {
                 fatal_with(
                     ExitCode::UserInputError,
                     format!(
-                        "checkpoint already exists at '{}': pass --resume '{}' to continue from it, --output-dir PATH to write elsewhere, or --no-checkpoint to disable checkpointing",
+                        "checkpoint already exists at '{}'.\nPossible solutions:\n  * pass '--resume {}' to continue from it\n  * pass '--output-dir <path>' to write elsewhere\n  * pass '--no-checkpoint' to disable checkpointing",
                         checkpoint_path.display(),
                         checkpoint_path.parent().unwrap().display()
                     ),

--- a/loader/cli.rs
+++ b/loader/cli.rs
@@ -8,8 +8,15 @@ use clap::Parser;
 
 pub const USERNAME_VALUE_NAME: &str = "username";
 
+/// The two invocation modes: a fresh load (connection, database, query, and data are required),
+/// and a resume (everything is carried by the checkpoint). Clap can't derive this because
+/// required-ness is only resolved after merging CLI args with the checkpoint.
+const USAGE: &str = "\
+typedb-loader --address <host:port> --username <user> --database <db> --query <query.tql> --data <data.csv> [OPTIONS]
+       typedb-loader --resume <output-dir> [OPTIONS]";
+
 #[derive(Parser, Debug)]
-#[command(author, about)]
+#[command(author, about, override_usage = USAGE)]
 pub struct Args {
     /// Path to a TypeQL query file used as the loading template.
     /// File path can be absolute or relative to the current directory.

--- a/loader/params.rs
+++ b/loader/params.rs
@@ -68,7 +68,7 @@ pub(crate) fn resolve_params(args: &Args, checkpoint: Option<&CheckpointParams>)
     if let (Some(cli_batch), Some(prior)) = (args.batch_rows, checkpoint) {
         if cli_batch != prior.batch_rows {
             return Err(format!(
-                "--batch-rows ({cli_batch}) differs from the checkpoint ({}); changing --batch-rows is not supported on resume",
+                "--batch-rows ({cli_batch}) differs from the checkpoint ({}); it cannot change on resume.\nPossible solutions:\n  * omit --batch-rows to reuse the checkpoint's value\n  * start a fresh run (without '--resume') to change the batch size",
                 prior.batch_rows
             ));
         }

--- a/loader/prompts.rs
+++ b/loader/prompts.rs
@@ -42,9 +42,12 @@ pub(crate) fn resolve_in_flight_skips(in_flight: &[InFlightBatch]) -> InFlightDe
     for batch in in_flight {
         eprintln!("  - batch {} (first row: {})", batch.batch_index, format_first_row(&batch.first_row));
     }
-    eprintln!(
-        "\nOptions: [a]ll = reprocess all, [s]kip all = treat as already committed, [d]ecide each,\n         [r]estart = discard the checkpoint and start over, [q]uit = abort the loader (default: all)"
-    );
+    eprintln!("\nOptions:");
+    eprintln!("  * [a]ll     = reprocess all (default)");
+    eprintln!("  * [s]kip    = treat all as already committed");
+    eprintln!("  * [d]ecide  = decide each batch individually");
+    eprintln!("  * [r]estart = discard the checkpoint and start over");
+    eprintln!("  * [q]uit    = abort the loader");
     let mode = loop {
         let choice = prompt("Choose action").trim().to_ascii_lowercase();
         match choice.as_str() {

--- a/loader/setup.rs
+++ b/loader/setup.rs
@@ -17,7 +17,13 @@ use crate::{ExitCode, fatal, fatal_with, params::Params};
 pub(crate) async fn connect_and_initialize(params: &Params, password: &str, resuming: bool) -> TypeDBDriver {
     let driver = connect(params, password).await;
     if !resuming && params.create_db {
-        create_database_if_missing(&driver, &params.database).await;
+        let created = create_database_if_missing(&driver, &params.database).await;
+        if created && params.schema_file.is_none() {
+            eprintln!(
+                "warning: created database '{}' without a schema; rows will be rejected unless a schema is applied before loading (see --schema-file)",
+                params.database
+            );
+        }
     }
     if !resuming {
         if let Some(path) = params.schema_file.as_deref() {
@@ -40,8 +46,9 @@ async fn connect(params: &Params, password: &str) -> TypeDBDriver {
         .unwrap_or_else(|err| fatal_with(ExitCode::ConnectionError, format!("failed to connect to TypeDB: {err}")))
 }
 
-/// Creates `database` if it does not already exist. No-op when it already exists.
-async fn create_database_if_missing(driver: &TypeDBDriver, database: &str) {
+/// Creates `database` if it does not already exist; returns whether it was created.
+/// No-op when it already exists.
+async fn create_database_if_missing(driver: &TypeDBDriver, database: &str) -> bool {
     let exists = driver
         .databases()
         .contains(database.to_owned())
@@ -54,6 +61,7 @@ async fn create_database_if_missing(driver: &TypeDBDriver, database: &str) {
             .await
             .unwrap_or_else(|err| fatal(format!("failed to create database '{database}': {err}")));
     }
+    !exists
 }
 
 /// Runs the supplied schema text in a schema transaction and commits it.


### PR DESCRIPTION
## Usage and product changes

- Reformat error messages with easier to read spacings
- warn when --create-db creates a database without a --schema-file
- override the clap usage line with one synopsis per invocation mode (fresh load vs --resume).

## Implementation
Update error messages and help menu